### PR TITLE
fix(core): handle case of deleted remote branch in log command

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -525,7 +525,7 @@ impl Git {
                 // per update.
                 let mut line = line;
 
-                if line.starts_with("Updating files") {
+                if line.contains("Updating files") {
                     line = "Updating files...".to_string();
                 }
 


### PR DESCRIPTION
This suppresses those git log failures when folks are on a quick submit branch.