### PR TITLE
fix(core): clone to correct path

### DIFF
--- a/birdie/src-tauri/src/repo/clone.rs
+++ b/birdie/src-tauri/src/repo/clone.rs
@@ -51,11 +51,13 @@ pub async fn clone_handler(
         .unwrap_or_default()
         .trim_end_matches(".git");
     let repo_path = PathBuf::from(&request.path).join(repo_name);
+    let repo_path_str = repo_path.to_str().unwrap_or_default();
 
     let tx = state.git_tx.clone();
+    let size_check_path = repo_path.clone();
     let status_handle = tokio::spawn(async move {
         loop {
-            let mut size = get_size(&repo_path).unwrap_or_default() as f64 / 1024.0 / 1024.0;
+            let mut size = get_size(&size_check_path).unwrap_or_default() as f64 / 1024.0 / 1024.0;
 
             if size > 1024.0 {
                 size /= 1024.0;
@@ -71,7 +73,13 @@ pub async fn clone_handler(
     state
         .git()
         .run(
-            &["clone", "--filter=tree:0", "--progress", &request.url],
+            &[
+                "clone",
+                "--filter=tree:0",
+                "--progress",
+                &request.url,
+                repo_path_str,
+            ],
             Default::default(),
         )
         .await?;

--- a/friendshipper/src-tauri/src/repo/operations/clone.rs
+++ b/friendshipper/src-tauri/src/repo/operations/clone.rs
@@ -52,11 +52,13 @@ pub async fn clone_handler(
         .unwrap_or_default()
         .trim_end_matches(".git");
     let repo_path = PathBuf::from(&request.path).join(repo_name);
+    let repo_path_str = repo_path.to_str().unwrap_or_default();
 
     let tx = state.git_tx.clone();
+    let size_check_path = repo_path.clone();
     let status_handle = tokio::spawn(async move {
         loop {
-            let mut size = get_size(&repo_path).unwrap_or_default() as f64 / 1024.0 / 1024.0;
+            let mut size = get_size(&size_check_path).unwrap_or_default() as f64 / 1024.0 / 1024.0;
 
             if size > 1024.0 {
                 size /= 1024.0;
@@ -80,7 +82,7 @@ pub async fn clone_handler(
                 "--filter=tree:0",
                 "--progress",
                 &request.url,
-                &request.path,
+                repo_path_str,
             ],
             Default::default(),
         )


### PR DESCRIPTION
We weren't putting the project name in the clone parameters, so we clone the repo one level higher than we should, oops!