### PR TITLE
fix(friendshipper): null message exception in ContributorLayout

### DIFF
--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -193,6 +193,18 @@
 		}
 	};
 
+	const getCommitMessage = (commit): string => {
+		if (commit != null) {
+			if (commit.message != null) {
+				const trimmed: string = commit.message.split('\n')[0];
+				if (trimmed != null) {
+					return trimmed;
+				}
+			}
+		}
+		return 'No message';
+	};
+
 	onMount(() => {
 		void refresh();
 
@@ -334,7 +346,7 @@
 									<TableBodyCell
 										class="p-2 text-primary-400 dark:text-primary-400 break-normal overflow-ellipsis overflow-hidden whitespace-nowrap w-1/2 max-w-[22vw]"
 									>
-										{node.headCommit.message.split('\n')[0] ?? 'No message'}
+										{getCommitMessage(node.headCommit)}
 									</TableBodyCell>
 									<TableBodyCell class="p-2 text-center"
 										>{node.headCommit.author.name}</TableBodyCell


### PR DESCRIPTION
Fixes this error I was seeing occasionally:

```
ContributorLayout.svelte:337  Uncaught (in promise) TypeError: Cannot read properties of null (reading 'message')
    at Array.create_default_slot_9 (ContributorLayout.svelte:337:28)
    at create_slot (utils.js:165:22)
    at create_dynamic_element9 (TableBody.svelte:1:46)
    at create_fragment126 (TableBodyCell.svelte:10:56)
    at init (Component.js:148:34)
    at new TableBodyCell (TableBodyCell.svelte:7:153)
    at Array.create_default_slot_4 (ContributorLayout.svelte:331:38)
    at create_slot (utils.js:165:22)
    at create_fragment127 (TableBodyCell.svelte:7:153)
    at init (Component.js:148:34)
```