### PR TITLE
fix(friendshipper): harden some failure cases

### DIFF
--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -47,25 +47,41 @@
 	let progressModalText = '';
 
 	const refreshPlaytests = async () => {
-		loadingPlaytests = true;
-		$playtests = await getPlaytests();
-		loadingPlaytests = false;
+		try {
+			loadingPlaytests = true;
+			$playtests = await getPlaytests();
+			loadingPlaytests = false;
+		} catch (e) {
+			await emit('error', e);
+		}
 	};
 
 	const refreshRepo = async () => {
-		loadingRepoStatus = true;
-		$repoStatus = await getRepoStatus();
-		loadingRepoStatus = false;
+		try {
+			loadingRepoStatus = true;
+			$repoStatus = await getRepoStatus();
+			loadingRepoStatus = false;
+		} catch (e) {
+			await emit('error', e);
+		}
 	};
 
 	const refreshMergeQueue = async () => {
-		loadingMergeQueue = true;
-		mergeQueue = await getMergeQueue();
-		loadingMergeQueue = false;
+		try {
+			loadingMergeQueue = true;
+			mergeQueue = await getMergeQueue();
+			loadingMergeQueue = false;
+		} catch (e) {
+			await emit('error', e);
+		}
 	};
 
 	const refresh = async () => {
-		await Promise.all([refreshPlaytests(), refreshRepo(), refreshMergeQueue()]);
+		try {
+			await Promise.all([refreshPlaytests(), refreshRepo(), refreshMergeQueue()]);
+		} catch (e) {
+			await emit('error', e);
+		}
 	};
 
 	const shouldDisableLaunchButton = (): boolean => {

--- a/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
@@ -249,14 +249,15 @@
 							{/if}
 						{/if}
 						<Button
-							disabled={$dynamicConfig.playtestDiscordChannels.length <= index}
+							disabled={$dynamicConfig.playtestDiscordChannels != null &&
+								$dynamicConfig.playtestDiscordChannels.length <= index}
 							outline
 							class="!p-2 w-full border-gray-300 dark:border-gray-300 hover:bg-primary-600 dark:hover:bg-primary-600"
 							on:click={() => openUrl($dynamicConfig.playtestDiscordChannels[index].url)}
 						>
 							<DiscordSolid class="text-white w-5 h-5" />
 						</Button>
-						{#if $dynamicConfig.playtestDiscordChannels.length > index}
+						{#if $dynamicConfig.playtestDiscordChannels != null && $dynamicConfig.playtestDiscordChannels.length > index}
 							<Tooltip
 								class="w-auto text-xs text-primary-400 bg-secondary-600 dark:bg-space-800"
 								placement="top">{$dynamicConfig.playtestDiscordChannels[index].name}</Tooltip

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -301,7 +301,11 @@
 				await emit('error', e);
 			}
 
-			playtests.set(await playtestsPromise);
+			try {
+				playtests.set(await playtestsPromise);
+			} catch (e) {
+				await emit('error', e);
+			}
 
 			if ($appConfig.repoPath !== '') {
 				try {


### PR DESCRIPTION
* Fix one null member 'message' when requesting merge queue results
* Handle several uncaught exceptions
* Note that you could repro these by connnecting normally to Friendshipper and then disconnecting your internet - we still spam error messages when disconnected, but at least it doesn't take down the frontend.