### PR TITLE
fix(friendshipper): run OFPA translate commandlet as unattended

### DIFF
--- a/friendshipper/src-tauri/src/system/unreal.rs
+++ b/friendshipper/src-tauri/src/system/unreal.rs
@@ -233,6 +233,7 @@ impl OFPANameCache {
                     let mut cmd = Command::new(editor_exe);
                     cmd.current_dir(&editor_dir);
                     cmd.arg(uproject_path);
+                    cmd.arg("-unattended");
                     cmd.arg("-Run=TranslateOFPAFilenames");
                     cmd.arg(format!("-ListFile=\'{}\'", listfile_path_str));
 


### PR DESCRIPTION
* Suppresses popups if the local build isn't in a good state, which happens to engineers all the time.