### PR TITLE
fix(friendshipper): more error handling

### DIFF
--- a/core/src/storage/entry.rs
+++ b/core/src/storage/entry.rs
@@ -206,7 +206,7 @@ impl ArtifactEntry {
         storage: &ArtifactStorage,
     ) -> Result<Self, CoreError> {
         let commit = self.commit.clone();
-        let path = storage.resolve_path(config)?;
+        let path = storage.resolve_path(config);
         // This only works for V1 schema
         Ok(Self::new(format!(
             "{}{}.json",

--- a/core/src/storage/mock/mod.rs
+++ b/core/src/storage/mock/mod.rs
@@ -20,6 +20,10 @@ impl MockArtifactProvider {
 
 #[async_trait]
 impl ArtifactProvider for MockArtifactProvider {
+    fn get_method_prefix(&self) -> MethodPrefix {
+        "file://".into()
+    }
+
     async fn get_artifact_by_prefix(&self, prefix: &str) -> Result<String, CoreError> {
         // TODO: Send back an actual longtail .json file to test with.
         match prefix.contains("fail") {
@@ -112,7 +116,7 @@ impl ArtifactProvider for MockArtifactProvider {
                 fake_entries.push(ArtifactEntry::new(format!("{}{}", path, "test/file/4")));
             }
         }
-        Ok(("file://".into(), fake_entries))
+        Ok((self.get_method_prefix(), fake_entries))
     }
 }
 

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -23,6 +23,7 @@
 		GameServerResult,
 		MergeQueue,
 		MergeQueueEntry,
+		Commit,
 		Playtest,
 		SyncClientRequest
 	} from '$lib/types';
@@ -209,7 +210,7 @@
 		}
 	};
 
-	const getCommitMessage = (commit): string => {
+	const getCommitMessage = (commit: Commit): string => {
 		if (commit != null) {
 			if (commit.message != null) {
 				const trimmed: string = commit.message.split('\n')[0];
@@ -219,6 +220,18 @@
 			}
 		}
 		return 'No message';
+	};
+
+	const getCommitAuthor = (commit: Commit): string => {
+		if (commit != null) {
+			if (commit.author != null) {
+				if (commit.author.name != null) {
+					return commit.author.name;
+				}
+			}
+		}
+
+		return '';
 	};
 
 	onMount(() => {
@@ -365,7 +378,7 @@
 										{getCommitMessage(node.headCommit)}
 									</TableBodyCell>
 									<TableBodyCell class="p-2 text-center"
-										>{node.headCommit.author.name}</TableBodyCell
+										>{getCommitAuthor(node.headCommit)}</TableBodyCell
 									>
 									<TableBodyCell class="p-2 text-center"
 										>{new Date(node.enqueuedAt).toLocaleString()}</TableBodyCell


### PR DESCRIPTION
* Handle an uncaught exception in the frontend related to null commit data
* Handle an invalid unwrap() when fetching artifacts from s3. Just return an empty list in this case to the caller and log the error.