### PR TITLE
fix(core): snapshots should not include deleted files

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -329,6 +329,12 @@ impl Git {
     ) -> anyhow::Result<Snapshot> {
         self.wait_for_lock().await;
 
+        // filter out any deleted files
+        let paths: Vec<String> = paths
+            .into_iter()
+            .filter(|path| self.repo_path.join(path).exists())
+            .collect();
+
         let mut args = vec!["add", "--"];
         for path in &paths {
             args.push(path);

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -286,6 +286,7 @@
 			selectAll = false;
 
 			await refreshPulls();
+			await refreshFiles(true);
 
 			await emit('success', 'Pull request opened!');
 		} catch (e) {


### PR DESCRIPTION
This wraps the SubmitOp's execution in a process that grabs a snapshot and tries to restore it on error. It also skips files missing from disk when storing a snapshot, as Git doesn't like it when you stash deleted files. In the future maybe we can find a way to snapshot deletes but it doesn't feel critical right now. 