### PR TITLE
chore(friendshipper): store the snapshot on the filesystem

### DIFF
--- a/birdie/src-tauri/src/repo/push.rs
+++ b/birdie/src-tauri/src/repo/push.rs
@@ -146,6 +146,7 @@ pub async fn push_handler(
         message: request.commit_message,
         repo_status: state.repo_status.clone(),
         git_client: state.git(),
+        skip_status_check: false,
     };
 
     sequence.push(Box::new(commit_op));

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -289,7 +289,6 @@ impl Git {
             .lines()
             .filter_map(|line| {
                 if !line.contains(SNAPSHOT_MESSAGE) {
-                    info!("Skipping line due to wrong message: {}", line);
                     return None;
                 }
 

--- a/core/src/operations.rs
+++ b/core/src/operations.rs
@@ -16,12 +16,13 @@ pub struct CommitOp {
     pub message: String,
     pub repo_status: RepoStatusRef,
     pub git_client: git::Git,
+    pub skip_status_check: bool,
 }
 
 #[async_trait]
 impl Task for CommitOp {
     async fn execute(&self) -> anyhow::Result<()> {
-        {
+        if !self.skip_status_check {
             let repo_status = self.repo_status.read();
             if !repo_status.has_staged_changes {
                 return Ok(());


### PR DESCRIPTION
Let's not even bother with real git stashes. This is more reliable it seems.