### PR TITLE
fix(friendshipper): commit message validation bugs

### DIFF
--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -278,7 +278,7 @@
 
 			$commitMessage = '';
 
-			tempCommitType = '';
+			// note that we don't reset tempCommitType because the UI already has a value selected
 			tempCommitScope = '';
 			tempCommitMessage = '';
 
@@ -478,7 +478,7 @@
 						<Select
 							bind:value={tempCommitType}
 							placeholder="Choose commit type"
-							on:input={() => {
+							on:change={() => {
 								$commitMessage = {
 									type: tempCommitType,
 									scope: tempCommitScope,
@@ -495,13 +495,13 @@
 						<Input
 							type="text"
 							bind:value={tempCommitScope}
-							on:input={() => {
-								commitMessageValid = validateCommitMessage();
+							on:keyup={() => {
 								$commitMessage = {
 									type: tempCommitType,
 									scope: tempCommitScope,
 									message: tempCommitMessage
 								};
+								commitMessageValid = validateCommitMessage();
 							}}
 							class="text-white bg-secondary-800 dark:bg-space-950"
 							placeholder="Scope (required)"
@@ -512,7 +512,7 @@
 					id="commit-message"
 					placeholder="Message (required)"
 					bind:value={tempCommitMessage}
-					on:input={() => {
+					on:keyup={() => {
 						if ($repoConfig?.useConventionalCommits) {
 							$commitMessage = {
 								type: tempCommitType,


### PR DESCRIPTION
* After performing a quicksubmit, the message type would get reset, but the UI still showed it as selected, leading to a state mismatch with the UI, which would cause the Quick Submit button to be disabled when it looked like everything was fine.
* For the type, scope, and message fields, the message validation was bound to the input event, which is executed _before_ the bound value was actually changed, causing the message validation to be 1-off. Switching to change/keyup events ensures the input is actually completed and the bound value is updated before commit message validation runs.