### PR TITLE
fix(core): unmerged files icon and block submit if conflicted upstream

### DIFF
--- a/birdie/src-tauri/src/repo/status.rs
+++ b/birdie/src-tauri/src/repo/status.rs
@@ -117,12 +117,7 @@ impl StatusOp {
         if status.commits_ahead > 0 {
             let range = format!("HEAD~{}...HEAD", status.commits_ahead);
 
-            let output = self.git_client.diff_filenames(&range).await?;
-            for line in output.lines() {
-                if !line.is_empty() {
-                    modified_committed.push(line.to_owned());
-                }
-            }
+            modified_committed = self.git_client.diff_filenames(&range).await?;
         }
 
         status.commit_head_origin = self
@@ -182,17 +177,8 @@ impl StatusOp {
         }
 
         // check files modified upstream
-        let mut modified_upstream: Vec<String> = vec![];
         let range = format!("HEAD...{}", status.remote_branch);
-
-        let output = self.git_client.diff_filenames(&range).await?;
-
-        for line in output.lines() {
-            if !line.is_empty() {
-                modified_upstream.push(line.to_owned());
-            }
-        }
-
+        let modified_upstream = self.git_client.diff_filenames(&range).await?;
         Ok(modified_upstream)
     }
 

--- a/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
+++ b/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
@@ -148,6 +148,9 @@
 		if (file.workingState === 'D') {
 			return ModifiedFileState.Deleted;
 		}
+		if (file.workingState === 'U') {
+			return ModifiedFileState.Unmerged;
+		}
 
 		if (file.indexState === 'A') {
 			return ModifiedFileState.Added;
@@ -157,6 +160,9 @@
 		}
 		if (file.indexState === 'D') {
 			return ModifiedFileState.Deleted;
+		}
+		if (file.indexState === 'U') {
+			return ModifiedFileState.Unmerged;
 		}
 
 		return ModifiedFileState.Unknown;
@@ -243,6 +249,13 @@
 								class="w-auto bg-secondary-600 dark:bg-space-800 font-semibold shadow-2xl"
 								placement="right"
 								>Deleted
+							</Tooltip>
+						{:else if getModifiedState(file) === ModifiedFileState.Unmerged}
+							<p class="w-4 h-4 mb-2 text-red-700">⚠️</p>
+							<Tooltip
+								class="w-auto bg-secondary-600 dark:bg-space-800 font-semibold shadow-2xl"
+								placement="right"
+								>Unmerged: revert to resolve
 							</Tooltip>
 						{/if}
 					</TableBodyCell>
@@ -334,6 +347,13 @@
 							class="w-auto bg-secondary-600 dark:bg-space-800 font-semibold shadow-2xl"
 							placement="right"
 							>Deleted
+						</Tooltip>
+					{:else if getModifiedState(file) === ModifiedFileState.Unmerged}
+						<p class="w-4 h-4 mb-2 text-red-700">⚠️</p>
+						<Tooltip
+							class="w-auto bg-secondary-600 dark:bg-space-800 font-semibold shadow-2xl"
+							placement="right"
+							>Unmerged
 						</Tooltip>
 					{/if}
 					<p class="font-bold {getFileTextClass(file)}">

--- a/core/ui/src/lib/types/repo.ts
+++ b/core/ui/src/lib/types/repo.ts
@@ -9,6 +9,7 @@ export enum ModifiedFileState {
 	Added = 'added',
 	Modified = 'modified',
 	Deleted = 'deleted',
+	Unmerged = 'unmerged',
 	Unknown = 'unknown'
 }
 

--- a/friendshipper/src-tauri/src/repo/operations/diff.rs
+++ b/friendshipper/src-tauri/src/repo/operations/diff.rs
@@ -9,14 +9,11 @@ use ethos_core::worker::Task;
 
 use crate::state::AppState;
 
-use super::RepoStatusRef;
-
 type DiffResponse = Vec<String>;
 
 #[derive(Clone)]
 pub struct DiffOp {
-    pub repo_path: String,
-    pub repo_status: RepoStatusRef,
+    pub trunk_branch: String,
     pub git_client: git::Git,
 }
 
@@ -35,13 +32,9 @@ impl Task for DiffOp {
 
 impl DiffOp {
     pub async fn run(&self) -> anyhow::Result<DiffResponse> {
-        let upstream_branch = self.repo_status.read().remote_branch.clone();
+        let upstream_branch = format!("origin/{}", self.trunk_branch);
 
-        let output = self.git_client.diff_filenames(&upstream_branch).await?;
-
-        let mut result = output.lines().map(|s| s.to_string()).collect::<Vec<_>>();
-        result.dedup();
-
+        let result = self.git_client.diff_filenames(&upstream_branch).await?;
         Ok(result)
     }
 }
@@ -53,8 +46,7 @@ where
     T: EngineProvider,
 {
     let diff_op = DiffOp {
-        repo_status: state.repo_status.clone(),
-        repo_path: state.app_config.read().repo_path.clone(),
+        trunk_branch: state.repo_config.read().trunk_branch.clone(),
         git_client: state.git(),
     };
 

--- a/friendshipper/src-tauri/src/repo/operations/log.rs
+++ b/friendshipper/src-tauri/src/repo/operations/log.rs
@@ -45,19 +45,18 @@ where
     let mut sequence = TaskSequence::new().with_completion_tx(tx);
 
     if params.update {
-        let status_op = {
-            StatusOp {
-                repo_status: state.repo_status.clone(),
-                app_config: state.app_config.clone(),
-                repo_config: state.repo_config.clone(),
-                engine: state.engine.clone(),
-                git_client: state.git(),
-                aws_client: aws_client.clone(),
-                storage: state.storage.read().clone().unwrap(),
-                skip_fetch: false,
-                skip_dll_check: false,
-                allow_offline_communication: false,
-            }
+        let status_op = StatusOp {
+            repo_status: state.repo_status.clone(),
+            app_config: state.app_config.clone(),
+            repo_config: state.repo_config.clone(),
+            engine: state.engine.clone(),
+            git_client: state.git(),
+            github_username: state.github_username(),
+            aws_client: aws_client.clone(),
+            storage: state.storage.read().clone().unwrap(),
+            skip_fetch: false,
+            skip_dll_check: false,
+            allow_offline_communication: false,
         };
 
         sequence.push(Box::new(status_op));

--- a/friendshipper/src-tauri/src/repo/operations/pull.rs
+++ b/friendshipper/src-tauri/src/repo/operations/pull.rs
@@ -50,22 +50,26 @@ where
     #[instrument(name = "PullOp::execute", skip(self))]
     async fn execute(&self) -> anyhow::Result<()> {
         info!("Pulling repo");
+        let github_username = self
+            .github_client
+            .clone()
+            .map_or(String::default(), |x| x.username.clone());
+
         self.engine.check_ready_to_sync_repo().await?;
 
         {
-            let status_op = {
-                StatusOp {
-                    repo_status: self.repo_status.clone(),
-                    app_config: self.app_config.clone(),
-                    repo_config: self.repo_config.clone(),
-                    engine: self.engine.clone(),
-                    git_client: self.git_client.clone(),
-                    aws_client: self.aws_client.clone(),
-                    storage: self.storage.clone(),
-                    skip_fetch: false,
-                    skip_dll_check: false,
-                    allow_offline_communication: false,
-                }
+            let status_op = StatusOp {
+                repo_status: self.repo_status.clone(),
+                app_config: self.app_config.clone(),
+                repo_config: self.repo_config.clone(),
+                engine: self.engine.clone(),
+                git_client: self.git_client.clone(),
+                github_username: github_username.clone(),
+                aws_client: self.aws_client.clone(),
+                storage: self.storage.clone(),
+                skip_fetch: false,
+                skip_dll_check: false,
+                allow_offline_communication: false,
             };
 
             status_op.execute().await?;
@@ -123,6 +127,7 @@ where
                         engine: self.engine.clone(),
                         app_config: self.app_config.clone(),
                         git_client: self.git_client.clone(),
+                        github_username: github_username.clone(),
                         aws_client: self.aws_client.clone(),
                         storage: self.storage.clone(),
                         skip_fetch: true,
@@ -141,6 +146,7 @@ where
                 engine: self.engine.clone(),
                 app_config: self.app_config.clone(),
                 git_client: self.git_client.clone(),
+                github_username: github_username.clone(),
                 aws_client: self.aws_client.clone(),
                 storage: self.storage.clone(),
                 skip_fetch: true,
@@ -204,6 +210,7 @@ where
                     repo_config: self.repo_config.clone(),
                     engine: self.engine.clone(),
                     git_client: self.git_client.clone(),
+                    github_username: github_username.clone(),
                     aws_client: self.aws_client.clone(),
                     storage: self.storage.clone(),
                     skip_fetch: true,

--- a/friendshipper/src-tauri/src/state.rs
+++ b/friendshipper/src-tauri/src/state.rs
@@ -199,6 +199,13 @@ where
             .expect("error forwarding git log");
     }
 
+    pub fn github_username(&self) -> String {
+        self.github_client
+            .read()
+            .clone()
+            .map_or(String::default(), |x| x.username.clone())
+    }
+
     pub async fn replace_aws_client(
         &self,
         client: AWSClient,


### PR DESCRIPTION
* Adds an icon for the unmerged state and a tooltip to hint that the user needs to revert the file to get back to a good state. Closes #122
* Rework upstream conflict checks to always use the upstream trunk branch. Rationale is that since if users are on a branch, they only really care about conflicting with changes that have landed in trunk, since they're in control of their own branch. This allows Unreal to know if a file has been modified in upstream trunk and appropriately warn the user.
* Disallow submitting files that have upstream conflicts - the user will wind up in a state where an engineer would need to fix up their remote branch, so it's better to catch this earlier.