### PR TITLE
fix(friendshipper): pass through project correctly when editing playtest

### DIFF
--- a/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
@@ -104,7 +104,7 @@
 				feedbackURL: data.feedbackURL
 			};
 
-			await updatePlaytest(playtest?.metadata.name, data.project, spec);
+			await updatePlaytest(playtest?.metadata.name, project, spec);
 		} else if (mode === ModalState.Creating) {
 			const spec: PlaytestSpec = {
 				displayName: data.name,


### PR DESCRIPTION
Turns out disabling a form input also stops the form from passing through that key in the form data. Oops!