### PR TITLE
perf(friendshipper): decrease time spent waiting for log + status refreshes

### DIFF
--- a/birdie/src-tauri/src/repo/log.rs
+++ b/birdie/src-tauri/src/repo/log.rs
@@ -7,7 +7,6 @@ use serde::Deserialize;
 
 use ethos_core::operations::{LogOp, LogResponse};
 use ethos_core::types::errors::CoreError;
-use ethos_core::worker::{NoOp, TaskSequence};
 
 use crate::state::AppState;
 
@@ -18,12 +17,6 @@ pub struct LogParams {
 
     #[serde(default)]
     pub use_remote: bool,
-
-    // Whether to force a fetch before getting the log
-    // This parameter does not get read
-    #[allow(dead_code)]
-    #[serde(default)]
-    pub update: bool,
 }
 
 fn default_limit() -> usize {
@@ -34,14 +27,6 @@ pub async fn log_handler(
     State(state): State<Arc<AppState>>,
     params: Query<LogParams>,
 ) -> Result<Json<LogResponse>, CoreError> {
-    // Make sure we wait for any queued updates
-    let (tx, rx) = tokio::sync::oneshot::channel::<Option<anyhow::Error>>();
-    let mut sequence = TaskSequence::new().with_completion_tx(tx);
-
-    sequence.push(Box::new(NoOp));
-    let _ = state.operation_tx.send(sequence).await;
-    let _ = rx.await;
-
     let log_op = LogOp {
         limit: params.limit,
         use_remote: params.use_remote,

--- a/core/src/tauri/command.rs
+++ b/core/src/tauri/command.rs
@@ -227,16 +227,11 @@ pub async fn get_commits(
     state: tauri::State<'_, State>,
     limit: Option<u32>,
     remote: Option<bool>,
-    update: Option<bool>,
 ) -> Result<Vec<Commit>, TauriError> {
     let mut req = state.client.get(format!("{}/repo/log", state.server_url));
 
     if let Some(limit) = limit {
         req = req.query(&[("limit", limit)]);
-    }
-
-    if let Some(update) = update {
-        req = req.query(&[("update", update)]);
     }
 
     if let Some(remote) = remote {

--- a/friendshipper/src-tauri/src/repo/operations/log.rs
+++ b/friendshipper/src-tauri/src/repo/operations/log.rs
@@ -2,16 +2,12 @@ use crate::engine::EngineProvider;
 use anyhow::anyhow;
 use axum::extract::{Query, State};
 use axum::Json;
-use ethos_core::clients::aws::ensure_aws_client;
 use ethos_core::operations::{LogOp, LogResponse};
 use ethos_core::types::errors::CoreError;
-use ethos_core::worker::{NoOp, TaskSequence};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::state::AppState;
-
-use super::StatusOp;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LogParams {
@@ -20,10 +16,6 @@ pub struct LogParams {
 
     #[serde(default)]
     pub use_remote: bool,
-
-    // Whether to force a fetch before getting the log
-    #[serde(default)]
-    pub update: bool,
 }
 
 fn default_limit() -> usize {
@@ -38,36 +30,6 @@ pub async fn log_handler<T>(
 where
     T: EngineProvider,
 {
-    let aws_client = ensure_aws_client(state.aws_client.read().await.clone())?;
-
-    // Make sure we wait for any queued updates
-    let (tx, rx) = tokio::sync::oneshot::channel::<Option<anyhow::Error>>();
-    let mut sequence = TaskSequence::new().with_completion_tx(tx);
-
-    if params.update {
-        let status_op = StatusOp {
-            repo_status: state.repo_status.clone(),
-            app_config: state.app_config.clone(),
-            repo_config: state.repo_config.clone(),
-            engine: state.engine.clone(),
-            git_client: state.git(),
-            github_username: state.github_username(),
-            aws_client: aws_client.clone(),
-            storage: state.storage.read().clone().unwrap(),
-            skip_fetch: false,
-            skip_dll_check: false,
-            allow_offline_communication: false,
-        };
-
-        sequence.push(Box::new(status_op));
-    } else {
-        sequence.push(Box::new(NoOp));
-    }
-
-    let _ = state.operation_tx.send(sequence).await;
-
-    let _ = rx.await;
-
     let log_op = LogOp {
         limit: params.limit,
         use_remote: params.use_remote,

--- a/friendshipper/src-tauri/src/repo/operations/status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/status.rs
@@ -14,6 +14,7 @@ use crate::repo::operations::gh::submit::is_quicksubmit_branch;
 use crate::state::AppState;
 use ethos_core::clients::aws::ensure_aws_client;
 use ethos_core::clients::git;
+use ethos_core::clients::git::ShouldPrune;
 use ethos_core::storage::{
     config::Project, ArtifactBuildConfig, ArtifactConfig, ArtifactKind, ArtifactList,
     ArtifactStorage, Platform,
@@ -101,9 +102,7 @@ where
     pub(crate) async fn run(&self) -> anyhow::Result<RepoStatus> {
         if !self.skip_fetch {
             info!("Fetching latest for {:?}", self.git_client.repo_path);
-            self.git_client
-                .run(&["fetch", "--prune"], git::Opts::default())
-                .await?;
+            self.git_client.fetch(ShouldPrune::Yes).await?;
         }
 
         info!("StatusOp: running git status...");

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -78,7 +78,8 @@
 
 	const refresh = async () => {
 		try {
-			await Promise.all([refreshPlaytests(), refreshRepo(), refreshMergeQueue()]);
+			// We don't need to refresh the repo because the root layout component will do that
+			await Promise.all([refreshPlaytests(), refreshMergeQueue()]);
 		} catch (e) {
 			await emit('error', e);
 		}


### PR DESCRIPTION
two minor enhancements here:
- our git log operation had a boolean for forcing a fetch, but it was never used, so i deleted it to avoid confusion. also, i deleted the `NoOp` operation blocking the `git log` call. this should significantly increase the performance of git log commands and reduce command queue saturation
- the window now needs to be focused for automating repo refreshes to occur, and when the window is focused, we automatically run a refresh if it's been longer than a minute since the previous refresh. the idea here is that many folks work in unreal with friendshipper minimized. while it's minimized, it's currently running StatusOp's every 30 seconds... but... so is Unreal. if you put yourself in a scenario where you're saving a file and you happen to intersect with the background status update, you may be queued for an extra second or two for basically no reason. 