### PR TITLE
fix(friendshipper): remove useless maintenance spans

### DIFF
--- a/core/src/clients/git_maintenance_runner.rs
+++ b/core/src/clients/git_maintenance_runner.rs
@@ -48,7 +48,6 @@ impl GitMaintenanceRunner {
         let fetch_task = tokio::task::spawn(async move {
             loop {
                 {
-                    let _ = tracing::info_span!("GitMaintenanceRunner::fetch").enter();
                     match git.fetch(ShouldPrune::Yes).await {
                         Ok(_) => {}
                         Err(e) => {
@@ -66,7 +65,6 @@ impl GitMaintenanceRunner {
         let maintenance_task = tokio::task::spawn(async move {
             loop {
                 {
-                    let _ = tracing::info_span!("GitMaintenanceRunner::maintenance").enter();
                     match git.run_maintenance().await {
                         Ok(_) => {
                             info!("Maintenance complete");


### PR DESCRIPTION
Very minor - but these spans don't provide any value and they aren't properly being parented anyhow. the maintenance runner is the only thing that runs `git maintenance` or `git fetch` so this just clears up some log spam. 