### PR TITLE
fix(core): allow RevertOp to skip engine check

### DIFF
--- a/core/src/types/repo.rs
+++ b/core/src/types/repo.rs
@@ -290,6 +290,8 @@ pub struct PushRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevertFilesRequest {
     pub files: Vec<String>,
+    #[serde(rename = "skipEngineCheck")]
+    pub skip_engine_check: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
* Needed for the case where the engine is directly requesting Friendshipper to revert files.