### PR TITLE
chore(friendshipper): disable gc.auto on startup

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -614,6 +614,10 @@ impl Git {
         Ok(entries)
     }
 
+    pub async fn set_config(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        self.run(&["config", key, value], Opts::default()).await
+    }
+
     pub async fn run_and_collect_output<'a>(
         &self,
         args: &[&str],

--- a/friendshipper/src-tauri/src/repo/operations/clone.rs
+++ b/friendshipper/src-tauri/src/repo/operations/clone.rs
@@ -102,5 +102,8 @@ where
         *lock = repo_config.clone();
     }
 
+    // set gc.auto 0
+    state.git().set_config("gc.auto", "0").await?;
+
     Ok(())
 }

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -175,7 +175,7 @@ impl Server {
                     .add_root(content_dir.as_path(), RecursiveMode::Recursive);
             }
 
-            // install git hooks
+            // install git hooks + set initial git config
             {
                 let hooks_state = shared_state.clone();
 
@@ -185,6 +185,9 @@ impl Server {
 
                 // avoids spamming a notification if repo/hooks paths are not configured
                 if !repo_path.is_empty() {
+                    let git = hooks_state.git().clone();
+                    git.set_config("gc.auto", "0").await?;
+
                     startup_tx.send("Installing git hooks".to_string())?;
                     if let Some(git_hooks_path) = git_hooks_path {
                         tokio::spawn(async move {


### PR DESCRIPTION
GC auto was causing problems with folks fetching w/ corrupt objects. We'll let the maintenance thread care about this from now on.