### PR TITLE
feat(friendshipper): add support for multiple playtest regions

### DIFF
--- a/core/src/types/config.rs
+++ b/core/src/types/config.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::AWS_REGION;
 use anyhow::{anyhow, bail, Result};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -101,8 +102,15 @@ pub struct AppConfig {
     #[serde(default, rename = "selectedArtifactProject")]
     pub selected_artifact_project: Option<String>,
 
+    #[serde(default = "default_playtest_region", rename = "playtestRegion")]
+    pub playtest_region: String,
+
     #[serde(default)]
     pub initialized: bool,
+}
+
+fn default_playtest_region() -> String {
+    AWS_REGION.to_string()
 }
 
 impl AppConfig {
@@ -136,6 +144,7 @@ impl AppConfig {
             record_play: false,
             aws_config: None,
             selected_artifact_project: None,
+            playtest_region: default_playtest_region(),
             initialized: false,
         }
     }
@@ -361,11 +370,8 @@ pub struct DynamicConfig {
     #[serde(skip_serializing_if = "Option::is_none", rename = "otlp_auth_header")]
     pub otlp_auth_header: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub loki_endpoint: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub loki_auth_header: Option<String>,
+    #[serde(default, rename = "playtestRegions")]
+    pub playtest_regions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/friendshipper/src-tauri/src/auth/router.rs
+++ b/friendshipper/src-tauri/src/auth/router.rs
@@ -56,7 +56,10 @@ where
         .await?;
 
         let username = state.app_config.read().user_display_name.clone();
-        state.replace_aws_client(new_aws_client, &username).await?;
+        let playtest_region = state.app_config.read().playtest_region.clone();
+        state
+            .replace_aws_client(new_aws_client, playtest_region, &username)
+            .await?;
     };
 
     let aws_client = ensure_aws_client(state.aws_client.read().await.clone())?;

--- a/friendshipper/src-tauri/src/config/router.rs
+++ b/friendshipper/src-tauri/src/config/router.rs
@@ -124,7 +124,7 @@ where
             None => true,
         };
 
-        if refresh_client {
+        if refresh_client || current_config.playtest_region != payload.playtest_region {
             info!("Initializing AWS client with new config");
             let new_aws_client = AWSClient::new(
                 Some(state.notification_tx.clone()),
@@ -140,7 +140,10 @@ where
             }
 
             let username = state.app_config.read().user_display_name.clone();
-            state.replace_aws_client(new_aws_client, &username).await?;
+            let playtest_region = payload.playtest_region.clone();
+            state
+                .replace_aws_client(new_aws_client, playtest_region, &username)
+                .await?;
         }
     }
 

--- a/friendshipper/src/lib/regions.ts
+++ b/friendshipper/src/lib/regions.ts
@@ -1,0 +1,19 @@
+// map of AWS regions
+export const regions: Record<string, string> = {
+	'us-east-1': 'US East (N. Virginia)',
+	'us-east-2': 'US East (Ohio)',
+	'us-west-1': 'US West (N. California)',
+	'us-west-2': 'US West (Oregon)',
+	'ap-south-1': 'Asia Pacific (Mumbai)',
+	'ap-northeast-2': 'Asia Pacific (Seoul)',
+	'ap-southeast-1': 'Asia Pacific (Singapore)',
+	'ap-southeast-2': 'Asia Pacific (Sydney)',
+	'ap-northeast-1': 'Asia Pacific (Tokyo)',
+	'ca-central-1': 'Canada (Central)',
+	'eu-central-1': 'EU (Frankfurt)',
+	'eu-west-1': 'EU (Ireland)',
+	'eu-west-2': 'EU (London)',
+	'eu-west-3': 'EU (Paris)',
+	'eu-north-1': 'EU (Stockholm)',
+	'sa-east-1': 'South America (Sao Paulo)'
+};

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface DiscordChannelInfo {
 export interface DynamicConfig {
 	maps: string[];
 	playtestDiscordChannels: DiscordChannelInfo[];
+	playtestRegions: string[];
 }
 
 export interface ProjectConfig {
@@ -42,6 +43,7 @@ export interface AppConfig {
 	recordPlay: boolean;
 	awsConfig: AWSConfig;
 	selectedArtifactProject: string;
+	playtestRegion: string;
 	initialized: boolean;
 }
 

--- a/friendshipper/src/routes/servers/+page.svelte
+++ b/friendshipper/src/routes/servers/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, Card, Spinner } from 'flowbite-svelte';
-	import { emit } from '@tauri-apps/api/event';
+	import { emit, listen } from '@tauri-apps/api/event';
 	import { onMount } from 'svelte';
 	import { CirclePlusOutline, RefreshOutline } from 'flowbite-svelte-icons';
 	import { get } from 'svelte/store';
@@ -41,6 +41,10 @@
 			await emit('error', e);
 		}
 	};
+
+	void listen('preferences-closed', () => {
+		void updateServers();
+	});
 
 	onMount(() => {
 		void updateServers();


### PR DESCRIPTION
This enables switching between regions for deploying playtests + servers. Enabled regions are enumerated as part of dynamic config. 

At present the default is still `us-west-2`. 