### PR TITLE
chore(friendshipper): unify snapshot behavior on submit

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -407,7 +407,11 @@ impl Git {
             stash_args.push(path);
         }
 
-        self.run(&stash_args, Opts::default()).await?;
+        // In testing, we found that regularly this would throw unlink errors when the editor was
+        // open. However, the snapshot still gets created successfully, so in this particular case
+        // we can ignore the error.
+        self.run(&stash_args, Opts::new_with_ignored(&["unable to unlink"]))
+            .await?;
 
         let snapshots = self.list_snapshots().await?;
 


### PR DESCRIPTION
This deprecates the behavior where we lay down a temporary `.stash` directory. 

What's interesting is that we're actually able to ignore the `unable to unlink` error that's thrown when the editor is open. I noticed in my testing that the snapshot totally works. Git must be attempting to touch some metadata on the file that is irrelevant to us. 