### PR TITLE
chore(core): update repo state with updated locks after lock op

### DIFF
--- a/birdie/src-tauri/src/repo/locks.rs
+++ b/birdie/src-tauri/src/repo/locks.rs
@@ -223,12 +223,17 @@ async fn internal_lock_handler(
         });
     }
 
+    let github_username = state.github_username();
+
     let lock_op = {
         LockOp {
             git_client: state.git(),
             paths,
             op,
+            response_tx: None,
             github_pat,
+            repo_status: state.repo_status.clone(),
+            github_username,
             force: request.force,
         }
     };

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -366,7 +366,7 @@ impl Git {
 
         // if any deleted files are manually chosen, return an error
         if paths.clone().into_iter().any(|p| {
-            let path = self.repo_path.join(&p);
+            let path = self.repo_path.join(p);
             !path.exists()
         }) {
             bail!("Cannot manually snapshot deleted files");

--- a/core/src/types/locks.rs
+++ b/core/src/types/locks.rs
@@ -53,7 +53,7 @@ pub struct VerifyLocksResponse {
     pub next_cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum LockOperation {
     Lock,
     Unlock,


### PR DESCRIPTION
* Now that we're pushing status updates to the engine, updating the repo status with the latest lock info ensures that it has more up-to-date locks info when sending status updates after a filewatch trigger.
* Moved the LockOp to be run in a task sequence to avoid racing with the status op