### PR TITLE
chore(birdie): unify update flow into core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "http-body 1.0.1",
  "httparse",
  "hyper 0.14.30",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -1710,12 +1710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1908,7 @@ dependencies = [
  "log",
  "log-panics",
  "obws",
+ "octocrab",
  "open 5.3.0",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2921,6 +2916,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2934,9 +2930,28 @@ dependencies = [
  "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-native-certs 0.7.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -2949,6 +2964,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2971,12 +2999,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
+ "socket2 0.5.7",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3383,15 +3416,15 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-rustls",
- "hyper-timeout",
+ "hyper-rustls 0.24.2",
+ "hyper-timeout 0.4.1",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
  "pin-project",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -4087,24 +4120,26 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfeeafb5fa0da7046229ec3c7b3bd2981aae05c549871192c408d59fc0fffd5"
+checksum = "9305e4c99543ecd0f42bd659c9e9d6ca7115fe5e37d5c85a7277b1db0d4c4101"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
  "either",
  "futures",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-rustls",
- "hyper-timeout",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.26.0",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
  "jsonwebtoken",
  "once_cell",
  "percent-encoding",
@@ -4117,7 +4152,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tower",
- "tower-http 0.4.4",
+ "tower-http 0.5.2",
  "tracing",
  "url",
 ]
@@ -5070,7 +5105,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5250,6 +5285,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
@@ -5270,7 +5319,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -5282,6 +5344,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5765,25 +5837,23 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
 dependencies = [
- "backtrace",
- "doc-comment",
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6538,6 +6608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6668,7 +6749,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
@@ -6714,10 +6795,8 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "http-range-header",
- "iri-string",
  "mime",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6731,10 +6810,13 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ directories-next = "2.0.0"
 keyring = "2"
 lazy_static = { version = "1.4.0", features = [] }
 log = "0.4.20"
+octocrab = "0.39.0"
 open = "5.0.0"
 opentelemetry = "0.21.0"
 opentelemetry-http = "0.10.0"

--- a/birdie/src-tauri/Cargo.toml
+++ b/birdie/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ directories-next = { workspace = true }
 keyring = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+octocrab = { workspace = true }
 open = { workspace = true }
 parking_lot = { workspace = true }
 reqwest = { workspace = true }
@@ -39,8 +40,6 @@ tracing-subscriber = { workspace = true }
 urlencoding = { workspace = true }
 
 ethos-core = { workspace = true }
-
-octocrab = "0.32.0"
 
 aws-sdk-s3 = { version = "1" }
 walkdir = "2.4.0"

--- a/birdie/src-tauri/src/system/update.rs
+++ b/birdie/src-tauri/src/system/update.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use axum::{debug_handler, extract::State};
-use octocrab::models::repos::Release;
 use octocrab::Octocrab;
 use tracing::{error, info};
 
 use ethos_core::types::errors::CoreError;
+use ethos_core::utils::update;
 use ethos_core::BIN_SUFFIX;
 
 use crate::state::AppState;
@@ -24,67 +24,14 @@ pub async fn get_latest_version(State(state): State<Arc<AppState>>) -> Result<St
     let octocrab = Octocrab::builder().personal_token(token.clone()).build()?;
 
     let app_name = APP_NAME.to_lowercase();
+    let latest =
+        update::get_latest_github_release(&octocrab, &app_name, REPO_OWNER, REPO_NAME).await?;
 
-    let releases = octocrab
-        .repos(REPO_OWNER, REPO_NAME)
-        .releases()
-        .list()
-        .send()
-        .await?;
-
-    let mut latest = releases
-        .into_iter()
-        .filter_map(|release| {
-            if release.draft || release.prerelease {
-                return None;
-            }
-
-            // if release doesn't match the format app_name-vX.Y.Z, skip it
-            if !release.tag_name.starts_with(&format!("{}-v", app_name)) {
-                return None;
-            }
-
-            // get semver
-            let version = release
-                .tag_name
-                .strip_prefix(&format!("{}-v", app_name))
-                .unwrap();
-            if semver::Version::parse(version).is_err() {
-                return None;
-            }
-
-            let tag_name = release.tag_name.clone();
-            if release
-                .assets
-                .iter()
-                .any(|asset| asset.name == format!("{}{}", &app_name, BIN_SUFFIX))
-            {
-                return Some(tag_name);
-            }
-
-            None
-        })
-        .collect::<Vec<String>>();
-
-    // sort by semver
-    latest.sort_by(|a, b| {
-        // we can unwrap because we asserted this format earlier
-        let a = a.strip_prefix(&format!("{}-v", &app_name)).unwrap();
-        let b = b.strip_prefix(&format!("{}-v", &app_name)).unwrap();
-        let a = semver::Version::parse(a).unwrap();
-        let b = semver::Version::parse(b).unwrap();
-
-        // reverse it
-        b.cmp(&a)
-    });
-
-    match latest.first() {
-        Some(latest) => Ok(latest
-            .strip_prefix(&format!("{}-v", APP_NAME))
-            .unwrap()
-            .to_string()),
-        None => Err(anyhow!("No latest version found").into()),
-    }
+    Ok(latest
+        .tag_name
+        .strip_prefix(&format!("{}-v", APP_NAME.to_lowercase()))
+        .unwrap()
+        .to_string())
 }
 
 #[debug_handler]
@@ -93,96 +40,70 @@ pub async fn run_update(State(state): State<Arc<AppState>>) -> Result<(), CoreEr
     let token = state.app_config.read().ensure_github_pat()?;
     let octocrab = Octocrab::builder().personal_token(token.clone()).build()?;
 
-    let releases = octocrab
-        .repos(REPO_OWNER, REPO_NAME)
-        .releases()
-        .list()
-        .send()
-        .await?;
+    let app_name = APP_NAME.to_lowercase();
 
-    let latest: Option<Release> = releases
-        .into_iter()
-        .filter_map(|release| {
-            if release.draft || release.prerelease {
-                return None;
+    let latest =
+        update::get_latest_github_release(&octocrab, &app_name, REPO_OWNER, REPO_NAME).await?;
+    let app_name = APP_NAME.to_lowercase();
+
+    let asset = latest
+        .assets
+        .iter()
+        .find(|asset| asset.name == format!("{}{}", &app_name, BIN_SUFFIX));
+
+    match asset {
+        Some(asset) => {
+            // download release
+            info!(
+                "https://api.github.com/repos/{}/{}/releases/assets/{}",
+                REPO_OWNER, REPO_NAME, asset.id
+            );
+
+            let client = reqwest::Client::new();
+            let mut response = client
+                .get(format!(
+                    "https://api.github.com/repos/{}/{}/releases/assets/{}",
+                    REPO_OWNER, REPO_NAME, asset.id
+                ))
+                .header("Accept", "application/octet-stream")
+                .header("User-Agent", app_name)
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await?;
+
+            if response.status().is_client_error() {
+                let text = response.text().await?;
+                error!("Error downloading asset: {:?}", text.clone());
+                return Err(CoreError(anyhow!("Error downloading asset: {:?}", text)));
             }
 
-            if release.tag_name.starts_with(APP_NAME)
-                && release
-                    .assets
-                    .iter()
-                    .any(|asset| asset.name == format!("{}{}", APP_NAME, BIN_SUFFIX))
-            {
-                return Some(release);
-            }
-
-            None
-        })
-        .next();
-
-    match latest {
-        Some(latest) => {
-            let asset = latest
-                .assets
-                .iter()
-                .find(|asset| asset.name == format!("{}{}", APP_NAME, BIN_SUFFIX));
-
-            match asset {
-                Some(asset) => {
-                    // download release
-                    info!(
-                        "https://api.github.com/repos/{}/{}/releases/assets/{}",
-                        REPO_OWNER, REPO_NAME, asset.id
-                    );
-
-                    let client = reqwest::Client::new();
-                    let mut response = client
-                        .get(format!(
-                            "https://api.github.com/repos/{}/{}/releases/assets/{}",
-                            REPO_OWNER, REPO_NAME, asset.id
-                        ))
-                        .header("Authorization", format!("Bearer {}", token))
-                        .header("Accept", "application/octet-stream")
-                        .header("User-Agent", APP_NAME)
-                        .send()
-                        .await?;
-
-                    if response.status().is_client_error() {
-                        let text = response.text().await?;
-                        error!("Error downloading asset: {:?}", text.clone());
-                        return Err(CoreError(anyhow!("Error downloading asset: {:?}", text)));
-                    }
-
-                    let exe_path = match std::env::current_exe() {
-                        Ok(path) => path,
-                        Err(e) => {
-                            return Err(anyhow!("Error getting current exe path: {:?}", e).into());
-                        }
-                    };
-
-                    let tmp_path = format!("{}_tmp", exe_path.to_str().unwrap());
-                    info!("Downloading to: {}", tmp_path);
-
-                    let mut file = File::create(tmp_path.clone())?;
-                    while let Some(chunk) = response.chunk().await? {
-                        file.write_all(&chunk)?;
-                    }
-
-                    match self_replace::self_replace(&tmp_path) {
-                        Ok(_) => {
-                            info!("Updated exe");
-                            fs::remove_file(&tmp_path)?;
-                            Ok(())
-                        }
-                        Err(e) => {
-                            error!("Error replacing exe: {:?}", e);
-                            Err(anyhow!("Error replacing exe: {:?}", e).into())
-                        }
-                    }
+            let exe_path = match std::env::current_exe() {
+                Ok(path) => path,
+                Err(e) => {
+                    return Err(anyhow!("Error getting current exe path: {:?}", e).into());
                 }
-                None => Err(anyhow!("No asset found").into()),
+            };
+
+            let tmp_path = format!("{}_tmp", exe_path.to_str().unwrap());
+            info!("Downloading to: {}", tmp_path);
+
+            let mut file = File::create(tmp_path.clone())?;
+            while let Some(chunk) = response.chunk().await? {
+                file.write_all(&chunk)?;
+            }
+
+            match self_replace::self_replace(&tmp_path) {
+                Ok(_) => {
+                    info!("Updated exe");
+                    fs::remove_file(&tmp_path)?;
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("Error replacing exe: {:?}", e);
+                    Err(anyhow!("Error replacing exe: {:?}", e).into())
+                }
             }
         }
-        None => Err(anyhow!("No latest version found").into()),
+        None => Err(anyhow!("No asset found").into()),
     }
 }

--- a/birdie/src/lib/config.ts
+++ b/birdie/src/lib/config.ts
@@ -1,11 +1,7 @@
 import { invoke } from '@tauri-apps/api/tauri';
-import type { DynamicConfig, AppConfig, RepoConfig } from '$lib/types';
-
-export const getDynamicConfig = async (): Promise<DynamicConfig> => invoke('get_dynamic_config');
+import type { AppConfig } from '$lib/types';
 
 export const getAppConfig = async (): Promise<AppConfig> => invoke('get_app_config');
 
 export const updateAppConfig = async (config: AppConfig): Promise<string> =>
 	invoke('update_app_config', { config });
-
-export const getRepoConfig = async (): Promise<RepoConfig> => invoke('get_repo_config');

--- a/birdie/src/routes/+layout.svelte
+++ b/birdie/src/routes/+layout.svelte
@@ -40,7 +40,6 @@
 		commits,
 		appConfig,
 		repoStatus,
-		repoConfig,
 		updateDismissed,
 		allModifiedFiles,
 		locks
@@ -48,7 +47,7 @@
 	import PreferencesModal from '$lib/components/preferences/PreferencesModal.svelte';
 	import { getLatestVersion, getLogPath, restart, runUpdate } from '$lib/system';
 	import WelcomeModal from '$lib/components/oobe/WelcomeModal.svelte';
-	import { getAppConfig, getRepoConfig } from '$lib/config';
+	import { getAppConfig } from '$lib/config';
 	import { getAllCommits, getRepoStatus, verifyLocks } from '$lib/repo';
 
 	// Initialization
@@ -169,7 +168,6 @@
 			const config = await getAppConfig();
 			appConfig.set(config);
 			if (config.repoPath !== '') {
-				repoConfig.set(await getRepoConfig());
 				repoStatus.set(await getRepoStatus());
 				commits.set(await getAllCommits());
 				locks.set(await verifyLocks());

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -84,3 +84,4 @@ toml = "0.8.8"
 async-trait = "0.1"
 windows = { version = "0.56.0", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 walkdir = "2.5.0"
+octocrab = "0.39.0"

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -5,4 +5,5 @@ pub mod logging;
 pub mod process;
 pub mod serde;
 pub mod tracing;
+pub mod update;
 pub mod windows;

--- a/core/src/utils/update.rs
+++ b/core/src/utils/update.rs
@@ -1,0 +1,75 @@
+use crate::BIN_SUFFIX;
+use anyhow::anyhow;
+use octocrab::models::repos::Release;
+use octocrab::Octocrab;
+
+pub async fn get_latest_github_release(
+    octocrab: &Octocrab,
+    app_name: &str,
+    repo_owner: &str,
+    repo_name: &str,
+) -> anyhow::Result<Release> {
+    let releases = octocrab
+        .repos(repo_owner, repo_name)
+        .releases()
+        .list()
+        .per_page(100)
+        .send()
+        .await?;
+
+    let mut latest = releases
+        .into_iter()
+        .filter_map(|release| {
+            if release.draft || release.prerelease {
+                return None;
+            }
+
+            // if release doesn't match the format app_name-vX.Y.Z, skip it
+            if !release.tag_name.starts_with(&format!("{}-v", app_name)) {
+                return None;
+            }
+
+            // get semver
+            let version = release
+                .tag_name
+                .strip_prefix(&format!("{}-v", app_name))
+                .unwrap();
+            if semver::Version::parse(version).is_err() {
+                return None;
+            }
+
+            if release
+                .assets
+                .iter()
+                .any(|asset| asset.name == format!("{}{}", &app_name, BIN_SUFFIX))
+            {
+                return Some(release);
+            }
+
+            None
+        })
+        .collect::<Vec<Release>>();
+
+    // sort by semver
+    latest.sort_by(|a, b| {
+        // we can unwrap because we asserted this format earlier
+        let a = a
+            .tag_name
+            .strip_prefix(&format!("{}-v", &app_name))
+            .unwrap();
+        let b = b
+            .tag_name
+            .strip_prefix(&format!("{}-v", &app_name))
+            .unwrap();
+        let a = semver::Version::parse(a).unwrap();
+        let b = semver::Version::parse(b).unwrap();
+
+        // reverse it
+        b.cmp(&a)
+    });
+
+    match latest.first() {
+        Some(latest) => Ok(latest.clone()),
+        None => Err(anyhow!("No latest version found")),
+    }
+}

--- a/friendshipper/src-tauri/Cargo.toml
+++ b/friendshipper/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ directories-next = { workspace = true }
 keyring = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+octocrab = { workspace = true }
 open = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["http-proto", "reqwest-client"] }
@@ -62,7 +63,6 @@ aws-sdk-s3 = { version = "1" }
 fs_extra = "1.3.0"
 
 json-patch = "1.1.0"
-octocrab = "0.32.0"
 graphql_client = { version = "0.13.0", features = ["reqwest"] }
 obws = "0.11.5"
 k8s-openapi = { version = "0.20.0", features = ["v1_24"] }


### PR DESCRIPTION
Now that both Birdie and Friendshipper use the GitHub releases flow for updates, they can share logic for detecting the latest version and updating. 

Also snuck in a small fix that removes a config endpoint Birdie was calling that doesn't exist for Birdie specifically. 