### PR TITLE
fix(core): only drop 26th stash when there are greater than 25

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -419,9 +419,9 @@ impl Git {
         let first = snapshots.first();
         assert!(first.is_some(), "Failed to get snapshot");
 
-        // if there are more than 10, `git stash drop` each one after the 10th
+        // if we have more than 25 snapshots, drop the oldest one
         if snapshots.len() > 25 {
-            for snapshot in snapshots.iter().skip(25) {
+            if let Some(snapshot) = snapshots.get(25) {
                 self.run(&["stash", "drop", &snapshot.stash_index], Opts::default())
                     .await?;
             }

--- a/friendshipper/src-tauri/src/builds/router.rs
+++ b/friendshipper/src-tauri/src/builds/router.rs
@@ -355,7 +355,6 @@ where
         let argolabels = workflow.metadata.labels.as_ref().unwrap();
         let argoannotations = workflow.metadata.annotations.as_ref().unwrap();
 
-        #[allow(clippy::manual_inspect)]
         workflow.status.as_mut().map(|s| {
             s.started_at = s.started_at.as_mut().map(|started_at| {
                 let f: DateTime<Local> = DateTime::parse_from_rfc3339(started_at)


### PR DESCRIPTION
If you drop a stash in the middle of the stack, all the indices change, duh! So in cases where we were trying to drop two stashes, we'd drop 1, then the 2nd one might go out of bounds. 