### PR TITLE
fix(core): put autostash flag at the end

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -241,17 +241,17 @@ impl Git {
         // TODO: handle alternative remotes
         let mut args = vec!["pull", "origin", &current_branch];
 
-        match stash_strategy {
-            PullStashStrategy::Autostash => args.push("--autostash"),
-            PullStashStrategy::None => {}
-        }
-
         match pull_strategy {
             PullStrategy::Rebase => args.push("--rebase"),
             PullStrategy::FFOnly => {
                 args.push("--ff-only");
                 args.push("--no-rebase");
             }
+        }
+
+        match stash_strategy {
+            PullStashStrategy::Autostash => args.push("--autostash"),
+            PullStashStrategy::None => {}
         }
 
         self.run(&args, Opts::default()).await


### PR DESCRIPTION
This is a little bit of a shot in the dark - git seems to sometimes be parsing `--autostash` as an additional ref argument, resulting in `cannot rebase onto multiple branches`. 