### PR TITLE
fix(birdie): use birdie specific get_config + update_config

### DIFF
--- a/birdie/src-tauri/src/command.rs
+++ b/birdie/src-tauri/src/command.rs
@@ -6,6 +6,8 @@ use birdie::metadata::{
     DirectoryClass, DirectoryMetadata, UpdateMetadataClassRequest, UpdateMetadataRequest,
 };
 use birdie::repo::{DeleteFetchIncludeRequest, DownloadFilesRequest, File};
+use birdie::types::config::BirdieConfig;
+
 use ethos_core::tauri::command::check_client_error;
 use ethos_core::tauri::error::TauriError;
 use ethos_core::types::commits::Commit;
@@ -13,6 +15,42 @@ use ethos_core::types::locks::VerifyLocksResponse;
 use ethos_core::types::repo::{CommitFileInfo, LockRequest, PushRequest, RepoStatus};
 
 use crate::State;
+
+#[tauri::command]
+pub async fn get_config(state: tauri::State<'_, State>) -> Result<BirdieConfig, TauriError> {
+    let res = state
+        .client
+        .get(format!("{}/config", state.server_url))
+        .send()
+        .await?;
+
+    if res.status().is_client_error() {
+        let body = res.text().await?;
+        return Err(TauriError { message: body });
+    }
+
+    Ok(res.json().await?)
+}
+
+#[tauri::command]
+pub async fn update_config(
+    state: tauri::State<'_, State>,
+    config: BirdieConfig,
+) -> Result<BirdieConfig, TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/config", state.server_url))
+        .json(&config)
+        .send()
+        .await?;
+
+    if res.status().is_client_error() {
+        let body = res.text().await?;
+        return Err(TauriError { message: body });
+    }
+
+    Ok(res.json().await?)
+}
 
 #[tauri::command]
 pub async fn show_commit_files(

--- a/birdie/src-tauri/src/lib.rs
+++ b/birdie/src-tauri/src/lib.rs
@@ -10,14 +10,14 @@ use ethos_core::middleware::nonce::NONCE;
 
 use crate::state::AppState;
 
-mod config;
+pub mod config;
 pub mod metadata;
 pub mod repo;
 pub mod server;
 mod state;
 mod system;
 pub mod tools;
-mod types;
+pub mod types;
 
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");
 pub static APP_NAME: &str = env!("CARGO_PKG_NAME");

--- a/birdie/src-tauri/src/main.rs
+++ b/birdie/src-tauri/src/main.rs
@@ -126,9 +126,7 @@ fn main() {
             fix_rebase,
             get_commits,
             get_all_files,
-            get_app_config,
             get_files,
-            update_app_config,
             get_directory_metadata,
             get_file_history,
             get_latest_version,
@@ -156,7 +154,9 @@ fn main() {
             update_metadata,
             update_metadata_class,
             sync_tools,
-            verify_locks
+            verify_locks,
+            get_config,
+            update_config
         ])
         .setup(move |app| {
             let handle = app.handle();

--- a/birdie/src/lib/components/preferences/PreferencesModal.svelte
+++ b/birdie/src/lib/components/preferences/PreferencesModal.svelte
@@ -4,7 +4,7 @@
 	import { emit } from '@tauri-apps/api/event';
 	import { open } from '@tauri-apps/api/dialog';
 	import { appConfig } from '$lib/stores';
-	import type { AppConfig } from '$lib/types';
+	import type { BirdieConfig } from '$lib/types';
 	import { getAppConfig, updateAppConfig } from '$lib/config';
 	import { openTerminalToPath } from '$lib/system';
 
@@ -13,7 +13,15 @@
 	export let showProgressModal: boolean;
 	export let handleCheckForUpdates: () => Promise<void>;
 
-	let localAppConfig: AppConfig = {};
+	let localAppConfig: BirdieConfig = {
+		repoPath: '',
+		repoUrl: '',
+		toolsPath: '',
+		toolsUrl: '',
+		userDisplayName: '',
+		githubPAT: '',
+		initialized: false
+	};
 	let checkForUpdatesInFlight = false;
 
 	const onOpen = () => {
@@ -21,21 +29,27 @@
 	};
 
 	const openRepoFolder = async () => {
-		localAppConfig.repoPath = await open({
+		const repoPath = await open({
 			directory: true,
 			multiple: false,
 			defaultPath: localAppConfig.repoPath || '.',
 			title: 'Select game repository folder'
 		});
+		if (typeof repoPath === 'string') {
+			localAppConfig.repoPath = repoPath;
+		}
 	};
 
 	const openToolsFolder = async () => {
-		localAppConfig.toolsPath = await open({
+		const toolsPath = await open({
 			directory: true,
 			multiple: false,
 			defaultPath: localAppConfig.toolsPath || '.',
 			title: 'Select game repository folder'
 		});
+		if (typeof toolsPath === 'string') {
+			localAppConfig.toolsPath = toolsPath;
+		}
 	};
 
 	const openTerminalToRepo = async () => {
@@ -123,7 +137,10 @@
 			<div class="flex flex-col gap-2">
 				<Label>Repo Path</Label>
 				<div class="flex gap-1 mb-2">
-					<Button class="h-8 gap-2" on:click={openRepoFolder}><FolderOpenSolid />Browse</Button>
+					<Button class="h-8 gap-2" on:click={openRepoFolder}>
+						<FolderOpenSolid />
+						Browse
+					</Button>
 					<ButtonGroup class="w-full">
 						<Input class="h-8" bind:value={localAppConfig.repoPath} />
 						<Tooltip class="text-sm" placement="bottom">
@@ -163,8 +180,10 @@
 					<div class="mt-2 mb-2 ml-2 mr-2">
 						<Label>Tools Path</Label>
 						<div class="flex gap-1 mb-2">
-							<Button class="h-8 gap-2" on:click={openToolsFolder}><FolderOpenSolid />Browse</Button
-							>
+							<Button class="h-8 gap-2" on:click={openToolsFolder}>
+								<FolderOpenSolid />
+								Browse
+							</Button>
 							<ButtonGroup class="w-full">
 								<Input class="h-8" bind:value={localAppConfig.toolsPath} />
 								<Tooltip class="text-sm" placement="bottom">

--- a/birdie/src/lib/config.ts
+++ b/birdie/src/lib/config.ts
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/tauri';
-import type { AppConfig } from '$lib/types';
+import type { BirdieConfig } from '$lib/types';
 
-export const getAppConfig = async (): Promise<AppConfig> => invoke('get_app_config');
+export const getAppConfig = async (): Promise<BirdieConfig> => invoke('get_config');
 
-export const updateAppConfig = async (config: AppConfig): Promise<string> =>
-	invoke('update_app_config', { config });
+export const updateAppConfig = async (config: BirdieConfig): Promise<string> =>
+	invoke('update_config', { config });

--- a/birdie/src/lib/stores.ts
+++ b/birdie/src/lib/stores.ts
@@ -1,9 +1,9 @@
 import { derived, type Readable, writable } from 'svelte/store';
 import type { Commit, ModifiedFile } from '@ethos/core';
-import type { AppConfig, Nullable, RepoStatus, LFSFile, VerifyLocksResponse } from '$lib/types';
+import type { BirdieConfig, Nullable, RepoStatus, LFSFile, VerifyLocksResponse } from '$lib/types';
 
 export const updateDismissed = writable(false);
-export const appConfig = writable(<AppConfig>{});
+export const appConfig = writable(<BirdieConfig>{});
 export const commits = writable(<Commit[]>[]);
 export const repoStatus = writable(<Nullable<RepoStatus>>null);
 export const currentRoot = writable('');

--- a/birdie/src/lib/types.ts
+++ b/birdie/src/lib/types.ts
@@ -3,7 +3,7 @@ import type { ModifiedFile } from '@ethos/core';
 export type Nullable<T> = T | null;
 
 // Config types
-export interface AppConfig {
+export interface BirdieConfig {
 	repoPath: string;
 	repoUrl: string;
 	toolsPath: string;


### PR DESCRIPTION
During cutover, I did not update the core get_app_config and update_app_config to handle two config types (friendshipper config and birdie config)

Fixed so that birdie owns it's own get/update_config commands