### PR TITLE
chore(friendshipper): force a restart to re-prompt auth

### DIFF
--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -39,6 +39,7 @@
 	import { getBuilds, syncClient } from '$lib/builds';
 	import { getServers } from '$lib/gameServers';
 	import UnrealEngineLogoNoCircle from '$lib/icons/UnrealEngineLogoNoCircle.svelte';
+	import { handleError } from '$lib/utils';
 
 	let loadingMergeQueue = false;
 	let loadingPlaytests = false;
@@ -53,9 +54,10 @@
 			loadingPlaytests = true;
 			$playtests = await getPlaytests();
 		} catch (e) {
-			await emit('error', e);
+			await handleError(e);
+		} finally {
+			loadingPlaytests = false;
 		}
-		loadingPlaytests = false;
 	};
 
 	const refreshRepo = async () => {

--- a/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
@@ -28,7 +28,7 @@
 		unassignUserFromPlaytest
 	} from '$lib/playtests';
 	import { appConfig, builds, dynamicConfig, playtests } from '$lib/stores';
-	import { openUrl } from '$lib/utils';
+	import { openUrl, handleError } from '$lib/utils';
 	import { getBuilds, syncClient } from '$lib/builds';
 	import { getServers } from '$lib/gameServers';
 
@@ -55,11 +55,11 @@
 
 		try {
 			await assignUserToGroup({ playtest: item.metadata.name, group: group.name, user });
+			const updatedPlaytests = await getPlaytests();
+			playtests.set(updatedPlaytests);
 		} catch (e) {
-			await emit('error', e);
+			await handleError(e);
 		}
-
-		playtests.set(await getPlaytests());
 		loading = false;
 	};
 
@@ -68,19 +68,23 @@
 
 		try {
 			await assignUserToGroup({ playtest: item.metadata.name, user });
+			const updatedPlaytests = await getPlaytests();
+			playtests.set(updatedPlaytests);
 		} catch (e) {
-			await emit('error', e);
+			await handleError(e);
 		}
-
-		playtests.set(await getPlaytests());
 		loading = false;
 	};
 
 	const handleUnassign = async (item: Playtest, user: string) => {
 		loading = true;
-		await unassignUserFromPlaytest(item.metadata.name, user);
-
-		playtests.set(await getPlaytests());
+		try {
+			await unassignUserFromPlaytest(item.metadata.name, user);
+			const updatedPlaytests = await getPlaytests();
+			playtests.set(updatedPlaytests);
+		} catch (e) {
+			await handleError(e);
+		}
 		loading = false;
 	};
 

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -2,6 +2,12 @@ import type { ModifiedFile } from '@ethos/core';
 
 export type Nullable<T> = T | null;
 
+// Error type
+export interface TauriError {
+	message: string;
+	status_code: number;
+}
+
 // Config types
 export interface DiscordChannelInfo {
 	name: string;

--- a/friendshipper/src/lib/utils.ts
+++ b/friendshipper/src/lib/utils.ts
@@ -1,5 +1,22 @@
+import { emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/tauri';
+import type { TauriError } from '$lib/types';
+import { restart } from '$lib/system';
+import { checkLoginRequired } from '$lib/auth';
 
 export const openUrl = async (url: string) => {
 	await invoke('open_url', { url });
+};
+
+export const handleError = async (e: unknown) => {
+	await emit('error', e);
+
+	const error = e as TauriError;
+	// check auth status
+	if (error.status_code === 401) {
+		const loginRequired = await checkLoginRequired();
+		if (loginRequired) {
+			await restart();
+		}
+	}
 };

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -65,6 +65,7 @@
 	import { getLatestVersion, openSystemLogsFolder, restart, runUpdate } from '$lib/system';
 	import WelcomeModal from '$lib/components/oobe/WelcomeModal.svelte';
 	import { getAppConfig, getDynamicConfig, getProjectConfig, getRepoConfig } from '$lib/config';
+	import { handleError } from '$lib/utils';
 
 	// Initialization
 	let appVersion = '';
@@ -310,7 +311,7 @@
 			try {
 				playtests.set(await playtestsPromise);
 			} catch (e) {
-				await emit('error', e);
+				await handleError(e);
 			}
 
 			if ($appConfig.repoPath !== '') {

--- a/friendshipper/src/routes/playtests/+page.svelte
+++ b/friendshipper/src/routes/playtests/+page.svelte
@@ -9,6 +9,7 @@
 	import { getPlaytests, ModalState } from '$lib/playtests';
 	import PlaytestCard from '$lib/components/playtests/PlaytestCard.svelte';
 	import PlaytestModal from '$lib/components/playtests/PlaytestModal.svelte';
+	import { handleError } from '$lib/utils';
 
 	let loading = false;
 	let showModal = false;
@@ -27,16 +28,26 @@
 		showModal = true;
 	};
 
-	const handleModalSubmit = async () => {
-		loading = true;
-		playtests.set(await getPlaytests());
-		loading = false;
-	};
-
 	const updatePlaytests = async () => {
 		loading = true;
-		playtests.set(await getPlaytests());
-		loading = false;
+		try {
+			playtests.set(await getPlaytests());
+		} catch (e) {
+			await handleError(e);
+		} finally {
+			loading = false;
+		}
+	};
+
+	const handleModalSubmit = async () => {
+		loading = true;
+		try {
+			await updatePlaytests();
+		} catch (e) {
+			await handleError(e);
+		} finally {
+			loading = false;
+		}
 	};
 
 	onMount(() => {


### PR DESCRIPTION
restarting seems like the safest way to make sure we don't make a bunch of requests after login expires.