### PR TITLE
fix(core): dedup lock paths

### DIFF
--- a/core/src/operations.rs
+++ b/core/src/operations.rs
@@ -235,11 +235,17 @@ impl LockOp {
             .connection_verbose(true)
             .build()
             .unwrap();
+        let unique_paths = {
+            let mut unique = self.paths.clone();
+            unique.sort();
+            unique.dedup();
+            unique
+        };
         let response = client
             .post(format!("{}/{}", server_url, endpoint))
             .bearer_auth(&self.github_pat)
             .json(&LockRequest {
-                paths: self.paths.clone(),
+                paths: unique_paths,
                 force: self.force,
             })
             .send()


### PR DESCRIPTION
* There have been some instances of lock paths being duplicated in the request, leading to failed lock requests. These changes ensure there are no duplicated paths in the request.