### PR TITLE
chore(core): make otel accessible during startup

### DIFF
--- a/birdie/src-tauri/src/main.rs
+++ b/birdie/src-tauri/src/main.rs
@@ -65,13 +65,14 @@ fn force_window_to_front(window: Window) {
 }
 
 fn main() {
-    let (log_path, _otel_reload_handle) = match logging::init(VERSION, APP_NAME) {
-        Ok(path) => path,
-        Err(e) => {
-            error!("Failed to initialize logging: {:?}", e);
-            std::process::exit(1);
-        }
-    };
+    let (log_path, _otel_reload_handle) =
+        match logging::init(VERSION, APP_NAME, VERSION, None, None, None) {
+            Ok(path) => path,
+            Err(e) => {
+                error!("Failed to initialize logging: {:?}", e);
+                std::process::exit(1);
+            }
+        };
 
     match utils::process::check_for_process(APP_NAME) {
         Ok(_) => {}

--- a/core/src/types/config.rs
+++ b/core/src/types/config.rs
@@ -104,6 +104,12 @@ pub struct AppConfig {
     #[serde(default = "default_playtest_region", rename = "playtestRegion")]
     pub playtest_region: String,
 
+    #[serde(skip_serializing_if = "Option::is_none", rename = "otlp_endpoint")]
+    pub otlp_endpoint: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", rename = "otlp_headers")]
+    pub otlp_headers: Option<String>,
+
     #[serde(default)]
     pub initialized: bool,
 }
@@ -144,6 +150,8 @@ impl AppConfig {
             aws_config: None,
             selected_artifact_project: None,
             playtest_region: default_playtest_region(),
+            otlp_endpoint: None,
+            otlp_headers: None,
             initialized: false,
         }
     }

--- a/friendshipper/src-tauri/src/auth/router.rs
+++ b/friendshipper/src-tauri/src/auth/router.rs
@@ -58,7 +58,13 @@ where
         let username = state.app_config.read().user_display_name.clone();
         let playtest_region = state.app_config.read().playtest_region.clone();
         state
-            .replace_aws_client(new_aws_client, playtest_region, &username)
+            .replace_aws_client(
+                new_aws_client,
+                playtest_region,
+                &username,
+                state.app_config.clone(),
+                state.config_file.clone(),
+            )
             .await?;
     };
 

--- a/friendshipper/src-tauri/src/config/router.rs
+++ b/friendshipper/src-tauri/src/config/router.rs
@@ -143,7 +143,13 @@ where
             let username = state.app_config.read().user_display_name.clone();
             let playtest_region = payload.playtest_region.clone();
             state
-                .replace_aws_client(new_aws_client, playtest_region, &username)
+                .replace_aws_client(
+                    new_aws_client,
+                    playtest_region,
+                    &username,
+                    state.app_config.clone(),
+                    state.config_file.clone(),
+                )
                 .await?;
         }
     }


### PR DESCRIPTION
This change allows us to start the app with otel running. For Birdie, because we don't yet have an otel mechanism, this does nothing yet. For Friendshipper, we now allow caching otel config returned from dynamic config in the local app config file. So, your very first start up will not be instrumented, but provided that there is otel config in dynamic config, subsequent startups will be instrumented. 