### PR TITLE
fix(friendshipper): disable offline OFPA translation on submit

### DIFF
--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -353,7 +353,7 @@ where
             github_username: self.github_client.username.clone(),
             aws_client: None,
             storage: None,
-            allow_offline_communication: true,
+            allow_offline_communication: false,
             skip_engine_update: false,
         };
 


### PR DESCRIPTION
* If UE is not open, just submit the files, running the commandlet takes way too long