### PR TITLE
feat(friendshipper): add logout button and more straightforward refre…

### DIFF
--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -872,3 +872,19 @@ pub async fn open_sln(state: tauri::State<'_, State>) -> Result<(), TauriError> 
     )
     .await
 }
+
+// logout
+#[tauri::command]
+pub async fn logout(state: tauri::State<'_, State>) -> Result<(), TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/auth/logout", state.server_url))
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    Ok(())
+}

--- a/friendshipper/src-tauri/src/main.rs
+++ b/friendshipper/src-tauri/src/main.rs
@@ -182,6 +182,7 @@ fn main() -> Result<(), CoreError> {
                 install_git,
                 launch_server,
                 list_snapshots,
+                logout,
                 open_logs_folder,
                 open_system_logs_folder,
                 open_terminal_to_path,

--- a/friendshipper/src/lib/auth.ts
+++ b/friendshipper/src/lib/auth.ts
@@ -5,3 +5,7 @@ export const checkLoginRequired = async (): Promise<boolean> => invoke('check_lo
 export const refreshLogin = async (): Promise<void> => {
 	await invoke('refresh_login');
 };
+
+export const logout = async (): Promise<void> => {
+	await invoke('logout');
+};

--- a/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
+++ b/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
@@ -35,6 +35,7 @@
 	import { resetRepo } from '$lib/repo';
 	import { getPlaytests } from '$lib/playtests';
 	import { regions } from '$lib/regions';
+	import { logout } from '$lib/auth';
 
 	export let showModal: boolean;
 	export let requestInFlight: boolean;
@@ -128,6 +129,22 @@
 	const onDiscardClicked = () => {
 		showModal = false;
 		void emit('preferences-closed');
+	};
+
+	const onLogoutClicked = async () => {
+		try {
+			showProgressModal = true;
+			progressModalTitle = 'Logging out...';
+			await logout();
+			showModal = false;
+
+			// wait 5 seconds before closing the modal
+			setTimeout(() => {
+				showProgressModal = false;
+			}, 5000);
+		} catch (e) {
+			await emit('error', e);
+		}
 	};
 
 	const handleResetConfig = async () => {
@@ -620,9 +637,12 @@
 	<div
 		class="absolute bottom-0 left-0 w-full p-4 rounded-b-lg border-t bg-secondary-700 dark:bg-space-900"
 	>
-		<div class="flex flex-row-reverse gap-2">
-			<Button outline on:click={onDiscardClicked}>Discard</Button>
-			<Button on:click={onApplyClicked}>Apply</Button>
+		<div class="flex flex-row-reverse justify-between gap-2">
+			<div class="flex gap-2">
+				<Button on:click={onApplyClicked}>Apply</Button>
+				<Button outline on:click={onDiscardClicked}>Discard</Button>
+			</div>
+			<Button color="red" on:click={onLogoutClicked}>Logout</Button>
 		</div>
 	</div>
 </Modal>


### PR DESCRIPTION
…sh procedure

This adds a `logout` button to the preferences modal.

It also attempts to simplify the logic that shows the login prompt, and fully wipes out the local creds when the client believes the token can not be refreshed. This should alleviate spammy unauthorized requests from the frontend.  