### PR TITLE
chore(friendshipper): stamp EpicInternal.txt sentinel for PII in crash uploads

### DIFF
--- a/friendshipper/src-tauri/src/builds/router.rs
+++ b/friendshipper/src-tauri/src/builds/router.rs
@@ -190,6 +190,8 @@ where
         Err(e) => return Err(CoreError::Internal(e.into())),
     }
 
+    T::post_download(&local_path).await;
+
     if let Some(launch_options) = payload.launch_options {
         info!(
             "Launching game client with server host {}:{}",

--- a/friendshipper/src-tauri/src/engine/provider.rs
+++ b/friendshipper/src-tauri/src/engine/provider.rs
@@ -25,6 +25,10 @@ pub trait EngineProvider: Clone + Send + Sync + 'static {
     /// Loads any internal caches the provider needs from disk
     async fn load_caches(&mut self);
 
+    /// Performs any post-download fixups necessary. Note that you must provide the path as
+    /// the user could be downloading a packaged build as well as the engine.
+    async fn post_download(path: &Path);
+
     /// Sends repo status updates to the engine
     async fn send_status_update(&self, status: &RepoStatus);
 

--- a/friendshipper/src-tauri/src/repo/operations/download_dlls.rs
+++ b/friendshipper/src-tauri/src/repo/operations/download_dlls.rs
@@ -47,6 +47,7 @@ pub struct DownloadDllsOp<T> {
     pub aws_client: AWSClient,
     pub artifact_prefix: String,
     pub engine: T,
+    pub engine_path: PathBuf,
 }
 
 #[async_trait]
@@ -169,6 +170,8 @@ where
             }
         }
 
+        T::post_download(&self.engine_path).await;
+
         info!(
             "download done. copying binaries from '{:?}' to: '{:?}'",
             binaries_staging_path, &self.git_client.repo_path
@@ -225,6 +228,11 @@ where
             .selected_artifact_project
             .context("Project not configured. Repo may still be initializing.")?;
 
+        let engine_path = state
+            .app_config
+            .read()
+            .load_engine_path_from_repo(&state.repo_config.read())?;
+
         DownloadDllsOp {
             git_client: state.git(),
             project_name,
@@ -236,6 +244,7 @@ where
             aws_client: aws_client.clone(),
             artifact_prefix,
             engine: state.engine.clone(),
+            engine_path,
         }
     };
 

--- a/friendshipper/src-tauri/src/repo/operations/pull.rs
+++ b/friendshipper/src-tauri/src/repo/operations/pull.rs
@@ -253,6 +253,10 @@ where
         };
 
         if app_config.pull_dlls {
+            let uproject = UProject::load(&uproject_path)?;
+
+            let engine_path = self.app_config.read().get_engine_path(&uproject);
+
             match RepoConfig::get_project_name(&uproject_path_relative) {
                 Some(project_name) => {
                     let download_op = DownloadDllsOp {
@@ -266,6 +270,7 @@ where
                         aws_client: self.aws_client.clone(),
                         artifact_prefix,
                         engine: self.engine.clone(),
+                        engine_path,
                     };
                     download_op.execute().await?
                 }
@@ -331,6 +336,7 @@ where
                     download_symbols: app_config.engine_download_symbols,
                     storage: self.storage.clone(),
                     project,
+                    engine: self.engine.clone(),
                 };
                 update_engine_op.execute().await?;
             }


### PR DESCRIPTION
* Unreal looks for the file Engine/Restricted/NotForLicensees/Build/EpicInternal.txt when it starts up to determine if the build can contain PII such as username and commandline. This info is important for engineers when tracing the source and cause of crashes, so we'll stamp it when the engine or client gets downloaded.