### PR TITLE
fix(friendshipper): misc pull operation fixes

### DIFF
--- a/friendshipper/src-tauri/src/engine/unreal/provider.rs
+++ b/friendshipper/src-tauri/src/engine/unreal/provider.rs
@@ -77,12 +77,14 @@ impl EngineProvider for UnrealEngineProvider {
 
     #[instrument(skip(self, status))]
     async fn send_status_update(&self, status: &RepoStatus) {
-        let client = reqwest::Client::new();
-        _ = client
-            .post("http://localhost:8091/friendshipper-ue/status/update".to_string())
-            .json(status)
-            .send()
-            .await;
+        if self.is_editor_process_running() {
+            let client = reqwest::Client::new();
+            _ = client
+                .post("http://localhost:8091/friendshipper-ue/status/update".to_string())
+                .json(status)
+                .send()
+                .await;
+        }
     }
 
     async fn check_ready_to_sync_repo(&self) -> Result<()> {


### PR DESCRIPTION
* Ensure if any files are stashed at the beginning of the pull operation, that they are popped if something goes wrong so the user retains their files and doesn't have to manually unstash them.
* The above also fixes a bug where if the user switched back to trunk from a f11r branch with local changes, but the pull exited early due to no new changes on latest, the files would stay in the stash and not get unstashed.
* When on trunk, remove one of the status updates that was unecessary. Saves a full status update time (~4-6s).
* Avoid running DLL search when running status at the beginning of the pull operation since the final status update will fetch that info. Saves ~3s.
* When refreshing status, only push changes to the Unreal engine process if it is actually running instead of letting the net request timeout. Saves ~2s.