### PR TITLE
chore(friendshipper): switch to user-specific query for PRs, show more

### DIFF
--- a/core/src/types/github/graphql/get_pull_requests.graphql
+++ b/core/src/types/github/graphql/get_pull_requests.graphql
@@ -1,29 +1,43 @@
-query GetPullRequests($owner: String!, $name: String!, $limit: Int!) {
-    repository(owner: $owner, name: $name) {
-        pullRequests(first: $limit, orderBy: { field: CREATED_AT, direction: DESC }) {
+query GetPullRequests($query: String!, $limit: Int!) {
+  search(query: $query, type: ISSUE, first: $limit) {
+    __typename
+    edges {
+      __typename
+      node {
+        ... on PullRequest {
+          __typename
+          number
+          createdAt
+          mergedAt
+          headRefName
+          state
+          mergeable
+          mergeQueueEntry {
             __typename
-            nodes {
-                __typename
-                number
-                createdAt
-                mergedAt
-                headRefName
-                state
-                mergeable
-                mergeQueueEntry {
-                    __typename
-                    estimatedTimeToMerge
-                    state
-                }
-                author {
-                    __typename
-                    login
-                }
-                merged
-                permalink
-                title
+            estimatedTimeToMerge
+            state
+          }
+          author {
+            __typename
+            login
+          }
+          merged
+          permalink
+          title
+          repository {
+            __typename
+            name
+            owner {
+              __typename
+              login
             }
-            totalCount
+          }
         }
+        __typename
+      }
+      __typename
     }
+    issueCount
+    __typename
+  }
 }

--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -9,7 +9,7 @@ use ethos_core::types::builds::SyncClientRequest;
 use ethos_core::types::config::{DynamicConfig, UnrealVerSelDiagResponse};
 use ethos_core::types::gameserver::{GameServerResults, LaunchRequest};
 use ethos_core::types::github::merge_queue::get_merge_queue::GetMergeQueueRepositoryMergeQueue;
-use ethos_core::types::github::pulls::get_pull_requests::GetPullRequestsRepositoryPullRequestsNodes;
+use ethos_core::types::github::pulls::get_pull_requests::GetPullRequestsSearchEdgesNodeOnPullRequest;
 use ethos_core::types::playtests::{
     AssignUserRequest, CreatePlaytestRequest, Playtest, UnassignUserRequest, UpdatePlaytestRequest,
 };
@@ -491,7 +491,7 @@ pub async fn get_pull_request(
 pub async fn get_pull_requests(
     state: tauri::State<'_, State>,
     limit: i64,
-) -> Result<Vec<GetPullRequestsRepositoryPullRequestsNodes>, TauriError> {
+) -> Result<Vec<GetPullRequestsSearchEdgesNodeOnPullRequest>, TauriError> {
     let res = state
         .client
         .get(format!(

--- a/friendshipper/src-tauri/src/repo/operations/gh/pulls.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/pulls.rs
@@ -4,11 +4,10 @@ use axum::Json;
 use serde::Deserialize;
 
 use crate::engine::EngineProvider;
+use crate::state::AppState;
 use ethos_core::types::errors::CoreError;
 use ethos_core::types::github::pulls::get_pull_request::GetPullRequestRepositoryPullRequest;
-use ethos_core::types::github::pulls::get_pull_requests::GetPullRequestsRepositoryPullRequestsNodes;
-
-use crate::state::AppState;
+use ethos_core::types::github::pulls::get_pull_requests::GetPullRequestsSearchEdgesNodeOnPullRequest;
 
 pub async fn get_pull_request<T>(
     State(state): State<AppState<T>>,
@@ -45,7 +44,7 @@ pub struct GetPullRequestsParams {
 pub async fn get_pull_requests<T>(
     State(state): State<AppState<T>>,
     params: Query<GetPullRequestsParams>,
-) -> Result<Json<Vec<GetPullRequestsRepositoryPullRequestsNodes>>, CoreError>
+) -> Result<Json<Vec<GetPullRequestsSearchEdgesNodeOnPullRequest>>, CoreError>
 where
     T: EngineProvider,
 {

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -887,7 +887,7 @@
 	</div>
 </div>
 <Card
-	class="w-full p-4 mt-2 sm:p-4 max-w-full min-h-[16rem] bg-secondary-700 dark:bg-space-900 border-0 shadow-none"
+	class="w-full p-4 mt-2 sm:p-4 max-w-full min-h-[20rem] h-[20rem] bg-secondary-700 dark:bg-space-900 border-0 shadow-none"
 >
 	<Tabs
 		style="underline"


### PR DESCRIPTION
This switches the get_pull_requests GraphQL query to use the search API and filter for the user's PRs. This lets us show a lot more history in the Submit view.

#7700405570