### PR TITLE
feat(friendshipper): allow waiting for server status before launching

### DIFF
--- a/core/src/clients/kube.rs
+++ b/core/src/clients/kube.rs
@@ -258,6 +258,11 @@ impl KubeClient {
                         None => (Some("Missing".to_string()), 0, 0),
                     };
 
+                    let ready = match &i.status {
+                        Some(v) => v.ready.unwrap_or(false),
+                        None => false,
+                    };
+
                     GameServerResults {
                         name: i.metadata.name.clone().unwrap(),
                         display_name: match i.spec.display_name.clone() {
@@ -269,6 +274,7 @@ impl KubeClient {
                         netimgui_port,
                         version: i.spec.version.clone(),
                         creation_timestamp: i.metadata.creation_timestamp.clone().unwrap(),
+                        ready,
                     }
                 })
                 .collect::<Vec<GameServerResults>>()),
@@ -283,6 +289,7 @@ impl KubeClient {
         check_for_existing: bool,
         display_name: &str,
         map: Option<String>,
+        include_readiness_probe: bool,
     ) -> Result<GameServer, CoreError> {
         let suffix: String = rand::thread_rng()
             .sample_iter(&Alphanumeric)
@@ -312,6 +319,7 @@ impl KubeClient {
                 display_name: Some(display_name.to_string()),
                 version: tag,
                 map,
+                include_readiness_probe,
             },
             status: None,
         };

--- a/core/src/types/gameserver.rs
+++ b/core/src/types/gameserver.rs
@@ -16,6 +16,8 @@ pub struct GameServerSpec {
     pub display_name: Option<String>,
     pub version: String,
     pub map: Option<String>,
+
+    pub include_readiness_probe: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
@@ -24,6 +26,9 @@ pub struct GameServerStatus {
     pub ip: Option<String>,
     pub port: i32,
     pub netimgui_port: i32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -36,6 +41,7 @@ pub struct GameServerResults {
     pub netimgui_port: i32,
     pub version: String,
     pub creation_timestamp: Time,
+    pub ready: bool,
 }
 
 impl GameServerResults {
@@ -54,4 +60,5 @@ pub struct LaunchRequest {
     pub check_for_existing: bool,
     pub display_name: String,
     pub map: Option<String>,
+    pub include_readiness_probe: bool,
 }

--- a/core/src/types/playtests.rs
+++ b/core/src/types/playtests.rs
@@ -41,6 +41,9 @@ pub struct GroupStatus {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready: Option<bool>,
 }
 
 #[derive(CustomResource, Default, Deserialize, Serialize, Clone, Debug, JsonSchema)]
@@ -73,6 +76,9 @@ pub struct PlaytestSpec {
     #[serde(rename = "usersToAutoAssign")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub users_to_auto_assign: Option<Vec<String>>,
+
+    #[serde(rename = "includeReadinessProbe")]
+    pub include_readiness_probe: bool,
 
     pub groups: Vec<Group>,
 }

--- a/friendshipper/src-tauri/src/builds/router.rs
+++ b/friendshipper/src-tauri/src/builds/router.rs
@@ -269,6 +269,7 @@ where
                 ip: status.ip,
                 port: status.port,
                 netimgui_port: status.netimgui_port,
+                ready: status.ready.unwrap_or(false),
             };
 
             let args = state.engine.create_launch_args(

--- a/friendshipper/src-tauri/src/servers/router.rs
+++ b/friendshipper/src-tauri/src/servers/router.rs
@@ -90,6 +90,7 @@ where
             request.check_for_existing,
             request.display_name.as_str(),
             request.map,
+            request.include_readiness_probe,
         )
         .await?;
 
@@ -192,6 +193,7 @@ where
                 netimgui_port: status.netimgui_port,
                 version: server.spec.version.clone(),
                 creation_timestamp: server.metadata.creation_timestamp.unwrap(),
+                ready: status.ready.unwrap_or(false),
             })),
             None => Err(CoreError::Internal(anyhow!("Server is not ready yet"))),
         },

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -212,7 +212,11 @@
 				);
 
 				if (playtestServer && entry) {
-					await handleSyncClient(entry, playtestServer);
+					if (playtestServer.ready) {
+						await handleSyncClient(entry, playtestServer);
+					} else {
+						await emit('error', 'Playtest server is not ready. Try again shortly.');
+					}
 				}
 			}
 		}

--- a/friendshipper/src/lib/components/home/PlaytestLayout.svelte
+++ b/friendshipper/src/lib/components/home/PlaytestLayout.svelte
@@ -213,21 +213,33 @@
 					);
 
 					if (playtestServer && entry) {
-						await handleSyncClient(entry, playtestServer);
+						if (playtestServer.ready) {
+							await handleSyncClient(entry, playtestServer);
+						} else {
+							await emit('error', 'Playtest server is not ready. Try again shortly.');
+						}
 						return;
 					}
 				} else {
 					const playtestServer = servers.find((s) => s.name === playtestAssignment.serverRef?.name);
 
 					if (playtestServer && entry) {
-						await handleSyncClient(entry, playtestServer);
+						if (playtestServer.ready) {
+							await handleSyncClient(entry, playtestServer);
+						} else {
+							await emit('error', 'Playtest server is not ready. Try again shortly.');
+						}
 						return;
 					}
 				}
 			}
 		}
 		if (servers.length > 0) {
-			await handleSyncClient(selected, servers[0]);
+			if (servers[0].ready) {
+				await handleSyncClient(selected, servers[0]);
+			} else {
+				await emit('error', 'Server is not ready. Try again shortly.');
+			}
 
 			return;
 		}
@@ -254,13 +266,22 @@
 
 		const server = servers.find((s) => s.displayName === name);
 		if (server) {
-			await handleSyncClient(selected, server);
+			if (server.ready) {
+				await handleSyncClient(selected, server);
+			} else {
+				await emit('error', 'Server is not ready. Try again shortly.');
+			}
 		}
 	};
 
 	void listen('quick-launch', (event) => {
 		const quickLaunchEvent = event.payload as QuickLaunchEvent;
 		void handleSyncClient(quickLaunchEvent.artifactEntry, quickLaunchEvent.server);
+		if (quickLaunchEvent.server.ready) {
+			void handleSyncClient(quickLaunchEvent.artifactEntry, quickLaunchEvent.server);
+		} else {
+			void emit('error', 'Server is not ready. Try again shortly.');
+		}
 	});
 
 	onMount(() => {

--- a/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
@@ -166,7 +166,11 @@
 						);
 
 						if (playtestServer && entry) {
-							await handleSyncClient(entry, playtestServer);
+							if (playtestServer.ready) {
+								await handleSyncClient(entry, playtestServer);
+							} else {
+								await emit('error', 'Playtest server is not ready. Try again shortly.');
+							}
 						}
 					}
 				} else if (entry) {
@@ -397,7 +401,7 @@
 					<div>
 						<div class="flex items-center justify-between gap-2">
 							<p class="text-base text-primary-400 font-semibold m-2 my-0">{group.name}</p>
-							<span class="text-sm">server {group.serverRef ? '🟢' : '🔴'}</span>
+							<span class="text-sm">server {group.ready ? '🟢' : '🔴'}</span>
 						</div>
 						<Hr classHr="my-2 bg-gray-300 dark:bg-gray-300" />
 						<div class="grid grid-cols-2 gap-1 mb-2">

--- a/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
@@ -113,7 +113,8 @@
 				playersPerGroup: parseInt(data.maxPlayersPerGroup, 10),
 				startTime: new Date(`${data.startDate} ${data.startTime}`).toISOString(),
 				groups: playtest.spec.groups,
-				feedbackURL: data.feedbackURL
+				feedbackURL: data.feedbackURL,
+				includeReadinessProbe: playtest?.spec.includeReadinessProbe ?? false
 			};
 
 			try {
@@ -129,6 +130,7 @@
 			}
 		} else if (mode === ModalState.Creating) {
 			const doNotPrune = !('autoCleanup' in data);
+			const includeReadinessProbe = 'includeReadinessProbe' in data;
 			const spec: PlaytestSpec = {
 				displayName: data.name,
 				version: data.version,
@@ -137,7 +139,8 @@
 				playersPerGroup: parseInt(data.maxPlayersPerGroup, 10),
 				startTime: new Date(`${data.startDate} ${data.startTime}`).toISOString(),
 				groups: [],
-				feedbackURL: data.feedbackURL
+				feedbackURL: data.feedbackURL,
+				includeReadinessProbe
 			};
 
 			const name = data.name.toLowerCase().replace(/[_\s/]/g, '-');
@@ -398,16 +401,30 @@
 				value={playtest ? playtest.spec.feedbackURL : ''}
 			/>
 		</Label>
-		<Label class="flex flex-row text-xs text-white">
-			<Checkbox
-				name="autoCleanup"
-				checked={playtest && playtest.metadata.annotations
-					? !playtest.metadata.annotations['believer.dev/do-not-prune']
-					: true}
-			/>
-			<span>Auto Cleanup</span>
-			<Tooltip>If toggled, this playtest will automatically delete in 24 hours.</Tooltip>
-		</Label>
+		<div class="flex flex-row gap-2">
+			<Label class="flex flex-row text-xs text-white">
+				<Checkbox
+					name="autoCleanup"
+					checked={playtest && playtest.metadata.annotations
+						? !playtest.metadata.annotations['believer.dev/do-not-prune']
+						: true}
+				/>
+				<span>Auto Cleanup</span>
+				<Tooltip>If toggled, this playtest will automatically delete in 24 hours.</Tooltip>
+			</Label>
+			<Label class="flex flex-row text-xs text-white">
+				<Checkbox
+					name="includeReadinessProbe"
+					disabled={mode === ModalState.Editing}
+					checked={(playtest && playtest.spec.includeReadinessProbe) ?? false}
+				/>
+				<span>Wait for server readiness</span>
+				<Tooltip>
+					If toggled, the playtest will wait for the server to be ready before starting. Version of
+					the deployed gameserver must support an HTTP readiness check.
+				</Tooltip>
+			</Label>
+		</div>
 		{#if playtestError}
 			<span class="text-xs bg-red-700 text-white p-2 rounded-md">
 				{playtestError}

--- a/friendshipper/src/lib/components/servers/ServerModal.svelte
+++ b/friendshipper/src/lib/components/servers/ServerModal.svelte
@@ -89,7 +89,11 @@
 		const server = servers.find((s) => s.displayName === name);
 		if (server) {
 			try {
-				await handleSyncClient(selected, server);
+				if (server.ready) {
+					await handleSyncClient(selected, server);
+				} else {
+					await emit('error', 'Server is not ready. Try again shortly.');
+				}
 				selected = get(selectedCommit);
 			} catch (e) {
 				await emit('error', e);

--- a/friendshipper/src/lib/components/servers/ServerTable.svelte
+++ b/friendshipper/src/lib/components/servers/ServerTable.svelte
@@ -63,7 +63,11 @@
 		};
 
 		try {
-			await syncClient(req);
+			if (server.ready) {
+				await syncClient(req);
+			} else {
+				await emit('error', 'Server is not ready. Try again shortly.');
+			}
 		} catch (e) {
 			await emit('error', e);
 		}

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -122,6 +122,7 @@ export interface GameServerResult {
 	netimguiPort: number;
 	version: string;
 	creationTimestamp: string;
+	ready: boolean;
 }
 
 export interface LaunchRequest {
@@ -146,10 +147,12 @@ export interface PlaytestSpec {
 	startTime: string;
 	feedbackURL: string;
 	groups?: Nullable<Group[]>;
+	includeReadinessProbe: boolean;
 }
 
 export interface GroupStatus extends Group {
 	serverRef?: LocalObjectReference;
+	ready: boolean;
 }
 
 export interface PlaytestStatus {


### PR DESCRIPTION
This relies on some new readiness capabilities in f11r-operator.

For now, if a user attempt to sync/launch for a server that's not ready, it'll early out and prompt to try again. Also, the status dots on playtest servers will now reflect whether or not the underlying pod is ready.