### PR TITLE
chore(friendshipper): drop unreal requests while it's in a slow task

### DIFF
--- a/friendshipper/src-tauri/src/engine/mod.rs
+++ b/friendshipper/src-tauri/src/engine/mod.rs
@@ -1,7 +1,10 @@
+pub mod router;
+
 mod provider;
 mod unreal;
 
 pub use provider::AllowMultipleProcesses;
 pub use provider::CommunicationType;
 pub use provider::EngineProvider;
+pub use router::router;
 pub use unreal::UnrealEngineProvider;

--- a/friendshipper/src-tauri/src/engine/provider.rs
+++ b/friendshipper/src-tauri/src/engine/provider.rs
@@ -87,4 +87,6 @@ pub trait EngineProvider: Clone + Send + Sync + 'static {
     ) -> Vec<String>;
 
     fn is_lockable_file(&self, filepath: &str) -> bool;
+
+    fn set_state(&self, in_slow_task: bool);
 }

--- a/friendshipper/src-tauri/src/engine/router.rs
+++ b/friendshipper/src-tauri/src/engine/router.rs
@@ -1,0 +1,34 @@
+use crate::state::AppState;
+use crate::EngineProvider;
+use axum::extract::{Query, State};
+use axum::routing::post;
+use axum::Router;
+use ethos_core::types::errors::CoreError;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::instrument;
+
+pub fn router<T>() -> Router<AppState<T>>
+where
+    T: EngineProvider,
+{
+    Router::new().route("/notify-state", post(notify_state))
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotifyStateParams {
+    in_slow_task: bool,
+}
+
+#[instrument(skip(state))]
+pub async fn notify_state<T>(
+    State(state): State<AppState<T>>,
+    params: Query<NotifyStateParams>,
+) -> Result<String, CoreError>
+where
+    T: EngineProvider,
+{
+    state.engine.set_state(params.in_slow_task);
+    Ok("ok".to_string())
+}

--- a/friendshipper/src-tauri/src/engine/unreal/ofpa.rs
+++ b/friendshipper/src-tauri/src/engine/unreal/ofpa.rs
@@ -185,6 +185,8 @@ impl OFPANameCache {
                     filenames: paths_to_request.clone(),
                 };
 
+                // See UnrealEngineProvider::send_status_update() implementation for an explanation of this approach to
+                // manually polling requests sent to Unreal.
                 let client = reqwest::Client::new();
                 let res_or_err_future = client
                     .post("http://localhost:8091/friendshipper-ue/ofpa/friendlynames".to_string())

--- a/friendshipper/src-tauri/src/engine/unreal/provider.rs
+++ b/friendshipper/src-tauri/src/engine/unreal/provider.rs
@@ -9,6 +9,7 @@ use ethos_core::types::config::AppConfig;
 use ethos_core::types::config::RepoConfig;
 use ethos_core::types::gameserver::GameServerResults;
 use ethos_core::types::repo::RepoStatus;
+use futures::FutureExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -22,6 +23,7 @@ pub struct UnrealEngineProvider {
     pub repo_path: PathBuf,
     pub uproject_path: PathBuf,
     pub ofpa_cache: OFPANameCacheRef,
+    pub can_handle_requests: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[async_trait]
@@ -32,6 +34,7 @@ impl EngineProvider for UnrealEngineProvider {
             repo_path: PathBuf::from(app_config.repo_path),
             uproject_path: PathBuf::from(repo_config.uproject_path),
             ofpa_cache: std::sync::Arc::new(parking_lot::RwLock::new(OFPANameCache::new())),
+            can_handle_requests: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         }
     }
 
@@ -79,13 +82,30 @@ impl EngineProvider for UnrealEngineProvider {
 
     #[instrument(skip(self, status))]
     async fn send_status_update(&self, status: &RepoStatus) {
-        if self.is_editor_process_running() {
+        if self.is_editor_process_running()
+            && self
+                .can_handle_requests
+                .load(std::sync::atomic::Ordering::Relaxed)
+        {
             let client = reqwest::Client::new();
-            _ = client
+            let future = client
                 .post("http://localhost:8091/friendshipper-ue/status/update".to_string())
                 .json(status)
-                .send()
-                .await;
+                .send();
+
+            tokio::pin!(future);
+
+            while self
+                .can_handle_requests
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                if future.as_mut().now_or_never().is_some() {
+                    break;
+                } else {
+                    tokio::task::yield_now().await;
+                }
+            }
+            warn!("Canceling status update request due to Unreal being busy");
         }
     }
 
@@ -162,6 +182,11 @@ impl EngineProvider for UnrealEngineProvider {
 
     fn is_lockable_file(&self, filepath: &str) -> bool {
         filepath.ends_with(".uasset") || filepath.ends_with(".umap") || filepath.ends_with(".dll")
+    }
+
+    fn set_state(&self, in_slow_task: bool) {
+        self.can_handle_requests
+            .store(!in_slow_task, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/friendshipper/src-tauri/src/lib.rs
+++ b/friendshipper/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ where
         .nest("/servers", servers::router())
         .nest("/storage", storage::router())
         .nest("/system", system::router())
+        .nest("/engine", engine::router())
         .route_layer(middleware::from_fn(move |headers, req, next| {
             nonce::nonce(headers, req, next, NONCE.as_str())
         })))

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -402,6 +402,7 @@ where
             aws_client: None,
             storage: None,
             allow_offline_communication: false,
+            skip_display_names: true,
             skip_engine_update: false,
         };
 

--- a/friendshipper/src-tauri/src/repo/operations/pull.rs
+++ b/friendshipper/src-tauri/src/repo/operations/pull.rs
@@ -92,6 +92,7 @@ where
                 aws_client: None,
                 storage: None,
                 allow_offline_communication: false,
+                skip_display_names: true,
                 skip_engine_update: false,
             };
 
@@ -167,6 +168,7 @@ where
                         aws_client: Some(self.aws_client.clone()),
                         storage: Some(self.storage.clone()),
                         allow_offline_communication: false,
+                        skip_display_names: true,
                         skip_engine_update: true,
                     }
                 };
@@ -247,6 +249,7 @@ where
                     aws_client: Some(self.aws_client.clone()),
                     storage: Some(self.storage.clone()),
                     allow_offline_communication: false,
+                    skip_display_names: true,
                     skip_engine_update: false,
                 }
             };

--- a/friendshipper/src-tauri/src/repo/operations/reset.rs
+++ b/friendshipper/src-tauri/src/repo/operations/reset.rs
@@ -88,6 +88,7 @@ where
             aws_client: Some(self.aws_client.clone()),
             storage: Some(self.storage.clone()),
             allow_offline_communication: false,
+            skip_display_names: true,
             skip_engine_update: false,
         };
         status_op.execute().await?;

--- a/friendshipper/src-tauri/src/repo/operations/status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/status.rs
@@ -76,6 +76,7 @@ where
     pub aws_client: Option<AWSClient>,
     pub storage: Option<ArtifactStorage>,
     pub allow_offline_communication: bool,
+    pub skip_display_names: bool,
     pub skip_engine_update: bool,
 }
 
@@ -191,7 +192,7 @@ where
         }
 
         // get display names if available
-        {
+        if !self.skip_display_names {
             // combine all the requested names into a single batch - this will avoid multiple potentially slow requests
             let mut all_filenames: Vec<String> = vec![];
             for file in status.modified_files.0.iter() {
@@ -587,6 +588,8 @@ pub struct StatusParams {
     #[serde(default)]
     pub allow_offline_communication: bool,
     #[serde(default)]
+    pub skip_display_names: bool,
+    #[serde(default)]
     pub skip_engine_update: bool,
 }
 
@@ -630,6 +633,7 @@ where
         aws_client,
         storage,
         allow_offline_communication: params.allow_offline_communication,
+        skip_display_names: params.skip_display_names,
         skip_engine_update: params.skip_engine_update,
     };
 


### PR DESCRIPTION
* Because Unreal can go into a blocking "slow task mode" on its' main thread and not ever respond to requests we issue, expose a new handler that Unreal can ping to say when it's going into/out of a slow task. When Unreal is in a slow task, we drop all existing requests to Unreal and don't allow new ones.