### PR TITLE
chore(core): fix linux dependency break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "walkdir",
  "which",
  "windows 0.56.0",
+ "zbus 5.5.0",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ tracing-appender = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 urlencoding = { workspace = true }
+zbus = { version = "5.5" }
 
 http = { version = "0.2.9" }
 


### PR DESCRIPTION
* graphql_client seems to not lock their dependency on zbus, which recently had a breaking change in the new 5.5.0 version. This change ensures we lock to versions less than 5.5.0 to avoid a build break on linux.