### PR TITLE
feat(core): pipe custom cmdline args to gameserver

### DIFF
--- a/core/src/clients/kube.rs
+++ b/core/src/clients/kube.rs
@@ -292,6 +292,7 @@ impl KubeClient {
         display_name: &str,
         map: Option<String>,
         include_readiness_probe: bool,
+        cmd_args: Vec<String>,
     ) -> Result<GameServer, CoreError> {
         let suffix: String = rand::thread_rng()
             .sample_iter(&Alphanumeric)
@@ -322,6 +323,7 @@ impl KubeClient {
                 version: tag,
                 map,
                 include_readiness_probe,
+                cmd_args: Some(cmd_args),
             },
             status: None,
         };

--- a/core/src/types/gameserver.rs
+++ b/core/src/types/gameserver.rs
@@ -18,6 +18,9 @@ pub struct GameServerSpec {
     pub map: Option<String>,
 
     pub include_readiness_probe: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cmd_args: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
@@ -61,4 +64,5 @@ pub struct LaunchRequest {
     pub display_name: String,
     pub map: Option<String>,
     pub include_readiness_probe: bool,
+    pub cmd_args: Vec<String>,
 }

--- a/core/src/types/playtests.rs
+++ b/core/src/types/playtests.rs
@@ -80,6 +80,10 @@ pub struct PlaytestSpec {
     #[serde(rename = "includeReadinessProbe")]
     pub include_readiness_probe: bool,
 
+    #[serde(rename = "gameServerCmdArgs")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub game_server_cmd_args: Option<Vec<String>>,
+
     pub groups: Vec<Group>,
 }
 

--- a/friendshipper/src-tauri/src/repo/operations/status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/status.rs
@@ -561,7 +561,7 @@ where
     }
 }
 
-#[instrument]
+#[instrument(skip(files))]
 fn find_dll_commit(files: &ArtifactList, long_shas: &str, context: &str) -> String {
     for sha in long_shas.lines() {
         let sha = sha.replace('"', "");

--- a/friendshipper/src-tauri/src/servers/router.rs
+++ b/friendshipper/src-tauri/src/servers/router.rs
@@ -92,6 +92,7 @@ where
             request.display_name.as_str(),
             request.map,
             request.include_readiness_probe,
+            request.cmd_args,
         )
         .await?;
 

--- a/friendshipper/src/lib/components/home/PlaytestLayout.svelte
+++ b/friendshipper/src/lib/components/home/PlaytestLayout.svelte
@@ -250,7 +250,8 @@
 			commit: selected.commit,
 			displayName: name,
 			checkForExisting: false,
-			includeReadinessProbe: false
+			includeReadinessProbe: false,
+			cmdArgs: []
 		};
 
 		if ($activeProjectConfig) {

--- a/friendshipper/src/lib/gameServers.ts
+++ b/friendshipper/src/lib/gameServers.ts
@@ -25,3 +25,10 @@ export const stopLogTail = async (): Promise<void> => invoke('stop_gameserver_lo
 
 export const copyProfileDataFromGameserver = async (name: string): Promise<void> =>
 	invoke('copy_profile_data_from_gameserver', { name });
+
+export const getServerArgsDisplayString = (args: string): string => {
+	if (args === '') {
+		return '';
+	}
+	return `(${args})`;
+};

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -68,6 +68,12 @@ export interface AppConfig {
 	initialized: boolean;
 }
 
+export interface PlaytestProfile {
+	name: string;
+	description: string;
+	args: string;
+}
+
 export interface RepoConfig {
 	uprojectPath: string;
 	trunkBranch: string;
@@ -75,6 +81,7 @@ export interface RepoConfig {
 	commitGuidelinesUrl?: string;
 	useConventionalCommits: boolean;
 	conventionalCommitsAllowedTypes: string[];
+	playtestProfiles: PlaytestProfile[];
 }
 
 // Kubernetes API types
@@ -133,6 +140,7 @@ export interface LaunchRequest {
 	displayName: string;
 	map?: string;
 	includeReadinessProbe: boolean;
+	cmdArgs: string[];
 }
 
 // Playtest types
@@ -151,6 +159,7 @@ export interface PlaytestSpec {
 	feedbackURL: string;
 	groups?: Nullable<Group[]>;
 	includeReadinessProbe: boolean;
+	gameServerCmdArgs: Nullable<string[]>;
 }
 
 export interface GroupStatus extends Group {


### PR DESCRIPTION
* New optional field in friendshipper.yaml: playtestProfiles. Use it to specify a set of cmdline args that will be passed to the game server. If empty, a default profile (empty) is generated automatically.
* Expose selection of server arg profiles in the Playtest and Server modal UIs.
* Plumb server arguments through to kube request