### PR TITLE
fix(core): playtest layout had null profiles

### DIFF
--- a/core/src/types/config.rs
+++ b/core/src/types/config.rs
@@ -333,7 +333,7 @@ impl Default for RepoConfig {
                 "test".to_string(),
                 "chore".to_string(),
             ],
-            playtest_profiles: vec![].into(),
+            playtest_profiles: Some(vec![]),
         }
     }
 }

--- a/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
@@ -434,26 +434,28 @@
 				value={playtest ? playtest.spec.feedbackURL : ''}
 			/>
 		</Label>
-		<div>
-			<Label class="flex flex-col text-xs text-white gap-2">
-				<span>Profile</span>
-				<Select
-					size="sm"
-					name="profile"
-					class={inputClass}
-					required
-					value={playtest ? playtest.spec.gameServerCmdArgs : profiles[0].name}
-					disabled={mode === ModalState.Editing}
-				>
-					{#each profiles as profile}
-						<option value={profile.name}>
-							<span>{profile.name}</span>
-							<span>{getServerArgsDisplayString(profile.value.args)}</span>
-						</option>
-					{/each}
-				</Select>
-			</Label>
-		</div>
+		{#if profiles !== null && profiles !== undefined && profiles.length > 0}
+			<div>
+				<Label class="flex flex-col text-xs text-white gap-2">
+					<span>Profile</span>
+					<Select
+						size="sm"
+						name="profile"
+						class={inputClass}
+						required
+						value={playtest ? playtest.spec.gameServerCmdArgs : profiles[0].name}
+						disabled={mode === ModalState.Editing}
+					>
+						{#each profiles as profile}
+							<option value={profile.name}>
+								<span>{profile.name}</span>
+								<span>{getServerArgsDisplayString(profile.value.args)}</span>
+							</option>
+						{/each}
+					</Select>
+				</Label>
+			</div>
+		{/if}
 		<div class="flex flex-row gap-2">
 			<Label class="flex flex-row text-xs text-white">
 				<Checkbox

--- a/friendshipper/src/lib/components/servers/ServerModal.svelte
+++ b/friendshipper/src/lib/components/servers/ServerModal.svelte
@@ -221,23 +221,25 @@
 				required
 			/>
 		</Label>
-		<Label class="space-y-2 text-xs text-white">
-			<span>Profile</span>
-			<Select
-				size="sm"
-				name="profile"
-				class="text-white bg-secondary-700 dark:bg-space-900"
-				bind:value={profile}
-				required
-			>
-				{#each profiles as profileItem}
-					<option value={profileItem.name}>
-						<span>{profileItem.name}</span>
-						<span>{getServerArgsDisplayString(profileItem.value.args)}</span>
-					</option>
-				{/each}
-			</Select>
-		</Label>
+		{#if profiles !== null && profiles !== undefined && profiles.length > 0}
+			<Label class="space-y-2 text-xs text-white">
+				<span>Profile</span>
+				<Select
+					size="sm"
+					name="profile"
+					class="text-white bg-secondary-700 dark:bg-space-900"
+					bind:value={profile}
+					required
+				>
+					{#each profiles as profileItem}
+						<option value={profileItem.name}>
+							<span>{profileItem.name}</span>
+							<span>{getServerArgsDisplayString(profileItem.value.args)}</span>
+						</option>
+					{/each}
+				</Select>
+			</Label>
+		{/if}
 		<Toggle class="text-white" bind:checked={autoLaunch} name="launch">
 			Sync client and join server immediately
 		</Toggle>


### PR DESCRIPTION
* Because we leave $repoConfig null when `repoPath` is null, we need to handle this case where we display UI for the playtest profiles. Simply not showing the profiles UI in this case is enough.