### PR TITLE
feat(friendshipper): reset engine in danger zone

### DIFF
--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -975,6 +975,22 @@ pub async fn force_download_engine(state: tauri::State<'_, State>) -> Result<(),
 }
 
 #[tauri::command]
+pub async fn reset_engine(state: tauri::State<'_, State>) -> Result<(), TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/repo/reset-engine", state.server_url))
+        .send()
+        .await?;
+
+    if let Some(err) = check_error(res.status(), res.text().await?).await {
+        error!("Error reset engine: {}", err.message);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn reinstall_git_hooks(state: tauri::State<'_, State>) -> Result<(), TauriError> {
     let res = state
         .client

--- a/friendshipper/src-tauri/src/main.rs
+++ b/friendshipper/src-tauri/src/main.rs
@@ -195,6 +195,7 @@ fn main() -> Result<(), CoreError> {
                 revert_files,
                 force_download_dlls,
                 force_download_engine,
+                reset_engine,
                 get_merge_queue,
                 open_url_for_path,
                 reinstall_git_hooks,

--- a/friendshipper/src-tauri/src/repo/operations/mod.rs
+++ b/friendshipper/src-tauri/src/repo/operations/mod.rs
@@ -17,7 +17,9 @@ pub use snapshot::{
     SaveSnapshotRequest,
 };
 pub use status::{status_handler, RepoStatusRef, StatusOp};
-pub use update_engine::{update_engine_handler, UpdateEngineOp};
+pub use update_engine::{
+    reset_engine_handler, update_engine_handler, UpdateEngineOp, WipeEngineOp,
+};
 
 pub use crate::repo::operations::gh::submit::GitHubSubmitOp;
 

--- a/friendshipper/src-tauri/src/repo/router.rs
+++ b/friendshipper/src-tauri/src/repo/router.rs
@@ -35,6 +35,7 @@ where
             post(operations::diagnostics::remediate_rebase_handler),
         )
         .route("/download-dlls", post(operations::download_dlls_handler))
+        .route("/reset-engine", post(operations::reset_engine_handler))
         .route("/download-engine", post(operations::update_engine_handler))
         .route("/checkout/trunk", post(operations::checkout_trunk_handler))
         .route(

--- a/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
+++ b/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
@@ -53,11 +53,13 @@
 		getAllCommits,
 		saveChangeSet,
 		loadChangeSet,
-		checkoutTargetBranch
+		checkoutTargetBranch,
+		resetEngine
 	} from '$lib/repo';
 	import { getPlaytests } from '$lib/playtests';
 	import { regions } from '$lib/regions';
 	import type { AppConfig, Nullable } from '$lib/types';
+	import { goto } from '$app/navigation';
 
 	export let showModal: boolean;
 	export let requestInFlight: boolean;
@@ -94,7 +96,7 @@
 			uptime = Math.floor((Date.now() - $startTime) / 1000);
 		}, 1000);
 		localAppConfig = structuredClone($appConfig);
-		console.log($repoConfig);
+
 		// initialize config types to empty object if needed
 		if (!localAppConfig.oktaConfig) {
 			localAppConfig.oktaConfig = {
@@ -352,6 +354,20 @@
 		} catch (e) {
 			await emit('error', e);
 		}
+	};
+
+	const handleResetEngine = async () => {
+		try {
+			showModal = false;
+
+			await goto('/source/history');
+			await emit('progress-modal', { show: true, title: 'Resetting Engine...' });
+			await resetEngine();
+			await emit('success', 'Engine wiped and redownloaded.');
+		} catch (e) {
+			await emit('error', e);
+		}
+		await emit('progress-modal', { show: false });
 	};
 
 	const handleResetLongtail = async () => {
@@ -958,6 +974,17 @@
 						</Button>
 						<span class="w-full">Reset Longtail installation (requires app restart)</span>
 					</div>
+					{#if localAppConfig.engineType === 'Prebuilt'}
+						<div class="flex gap-2 items-center">
+							<Button
+								outline
+								class="w-1/2 border-white dark:border-white text-white dark:text-white hover:bg-red-900 dark:hover:bg-red-900"
+								on:click={handleResetEngine}
+								>Reset Engine
+							</Button>
+							<span class="w-full">Completely delete and redownload engine</span>
+						</div>
+					{/if}
 					<div class="flex gap-2 items-center">
 						<Button
 							outline

--- a/friendshipper/src/lib/repo.ts
+++ b/friendshipper/src/lib/repo.ts
@@ -113,6 +113,8 @@ export const forceDownloadDlls = async (): Promise<void> => invoke('force_downlo
 
 export const forceDownloadEngine = async (): Promise<void> => invoke('force_download_engine');
 
+export const resetEngine = async (): Promise<void> => invoke('reset_engine');
+
 export const reinstallGitHooks = async (): Promise<void> => invoke('reinstall_git_hooks');
 
 export const syncEngineCommitWithUproject = async (): Promise<string> =>

--- a/friendshipper/src/routes/source/history/+page.svelte
+++ b/friendshipper/src/routes/source/history/+page.svelte
@@ -9,7 +9,7 @@
 		DropdownItem
 	} from 'flowbite-svelte';
 	import { ChevronDownOutline, RefreshOutline, FileCodeSolid } from 'flowbite-svelte-icons';
-	import { emit } from '@tauri-apps/api/event';
+	import { emit, listen } from '@tauri-apps/api/event';
 	import { CommitTable, ProgressModal } from '@ethos/core';
 	import {
 		getAllCommits,
@@ -193,6 +193,13 @@
 
 		inAsyncOperation = false;
 	};
+
+	void listen('progress-modal', (event) => {
+		inAsyncOperation = event.payload.show;
+		if (inAsyncOperation) {
+			asyncModalText = event.payload.title as string;
+		}
+	});
 </script>
 
 <div class="flex items-center justify-between gap-2">


### PR DESCRIPTION
* There have been several cases where people have reported broken engines after switching to a branch with a different engine and updating. This adds a mitigation where users can have a convenient button that will delete all prebuilt engine binaries and data, and redownload it.