### PR TITLE
chore(core): harden longtail get_archive()

### DIFF
--- a/friendshipper/src-tauri/src/repo/operations/update_engine.rs
+++ b/friendshipper/src-tauri/src/repo/operations/update_engine.rs
@@ -160,7 +160,7 @@ where
                     &PathBuf::from(&self.engine_path),
                     Some(longtail::CacheControl {
                         path: cache_path,
-                        max_size_bytes: 50 * 1024 * 1024 * 1024, // 50 GB
+                        max_size_bytes: 100 * 1024 * 1024 * 1024, // 100 GB
                     }),
                     &archive_urls,
                     self.longtail_tx.clone(),


### PR DESCRIPTION
* When retrying a download, clear the target download path in addition to the cache. Longtail seems to have trouble sometimes if there are already files there.