### PR TITLE
fix(core): assorted target branch swapping fixes

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -671,7 +671,7 @@ impl Git {
                 Opts::default(),
             )
             .await?;
-        let behind_count = output.lines().next().unwrap_or("0").parse::<u32>().unwrap();
+        let behind_count = output.lines().next().unwrap_or("0").parse::<u32>()?;
 
         let output = self
             .run_and_collect_output(
@@ -684,7 +684,7 @@ impl Git {
                 Opts::default(),
             )
             .await?;
-        let ahead_count = output.lines().next().unwrap_or("0").parse::<u32>().unwrap();
+        let ahead_count = output.lines().next().unwrap_or("0").parse::<u32>()?;
 
         Ok((ahead_count, behind_count))
     }

--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -1050,6 +1050,22 @@ pub async fn sync_uproject_commit_with_engine(
     Ok(response_text)
 }
 
+#[tauri::command]
+pub async fn check_engine_ready(state: tauri::State<'_, State>) -> Result<bool, TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/engine/check-engine-ready", state.server_url))
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    let response_text = res.text().await?;
+    Ok(response_text == "true")
+}
+
 async fn generate_and_open_sln(
     url: String,
     open: bool,

--- a/friendshipper/src-tauri/src/main.rs
+++ b/friendshipper/src-tauri/src/main.rs
@@ -143,6 +143,7 @@ fn main() -> Result<(), CoreError> {
             .invoke_handler(tauri::generate_handler![
                 assign_user_to_group,
                 cancel_download,
+                check_engine_ready,
                 check_login_required,
                 checkout_trunk,
                 checkout_target_branch,

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -330,7 +330,7 @@
 						</div>
 						<div class="flex gap-2 items-center">
 							<p class="w-full text-white">
-								Commits behind <code>{$repoConfig?.trunkBranch}</code>:
+								Commits behind <code>{$appConfig?.targetBranch}</code>:
 							</p>
 							<p class="w-full text-primary-400 dark:text-primary-400">
 								{$repoStatus?.commitsBehindTrunk}

--- a/friendshipper/src/lib/engine.ts
+++ b/friendshipper/src/lib/engine.ts
@@ -1,3 +1,4 @@
 import { invoke } from '@tauri-apps/api/core';
 
 export const openUrlForPath = async (path: string) => invoke('open_url_for_path', { path });
+export const checkEngineReady = async (): Promise<boolean> => invoke('check_engine_ready');

--- a/friendshipper/src/lib/stores.ts
+++ b/friendshipper/src/lib/stores.ts
@@ -38,6 +38,7 @@ export const changeSets = writable(<ChangeSet[]>[]);
 export const startTime = writable(Date.now());
 export const backgroundSyncInProgress = writable(false);
 export const currentSyncedVersion = writable('');
+export const showPreferences = writable(false);
 
 export const nextPlaytest = derived([playtests, appConfig], ([$playtests, $appConfig]) => {
 	if ($playtests.length > 0) {

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -59,6 +59,7 @@
 		repoConfig,
 		repoStatus,
 		selectedCommit,
+		showPreferences,
 		updateDismissed,
 		workflows
 	} from '$lib/stores';
@@ -101,7 +102,6 @@
 	let showWelcomeModal = false;
 
 	// Preferences Modal
-	let showPreferencesModal = false;
 	let showProgressModal = false;
 	let progressModalTitle: string = '';
 	let preferencesModalRequestInFlight = false;
@@ -170,11 +170,12 @@
 	const handleCheckForUpdates = async () => {
 		try {
 			const update = await check();
-			latest = update?.version ?? '';
-			updateAvailable = update?.available ?? false;
 
-			if (updateAvailable) {
-				showPreferencesModal = false;
+			if (update !== null) {
+				updateAvailable = true;
+				latest = update?.version ?? '';
+
+				$showPreferences = false;
 				updateDismissed.set(false);
 			}
 		} catch (e) {
@@ -512,7 +513,7 @@
 		});
 
 		const refresh = async () => {
-			if (!$appConfig.initialized || $onboardingInProgress) return;
+			if (!$appConfig.initialized || $onboardingInProgress || $showPreferences) return;
 
 			const buildsPromise = getBuilds(250);
 			const playtestsPromise = getPlaytests();
@@ -562,7 +563,7 @@
 			try {
 				const update = await check();
 				latest = update?.version ?? '';
-				updateAvailable = update?.available ?? false;
+				updateAvailable = update !== null;
 			} catch (e) {
 				await emit('error', e);
 			}
@@ -657,7 +658,7 @@
 	});
 
 	void listen('open-preferences', () => {
-		showPreferencesModal = true;
+		$showPreferences = true;
 	});
 
 	void listen('scheme-request-received', (e) => {
@@ -699,7 +700,7 @@
 {/key}
 
 <PreferencesModal
-	bind:showModal={showPreferencesModal}
+	bind:showModal={$showPreferences}
 	bind:requestInFlight={preferencesModalRequestInFlight}
 	bind:showProgressModal
 	bind:progressModalTitle
@@ -989,7 +990,7 @@
 									class="!p-2 active:border-none focus:outline-none"
 									label="Preferences"
 									on:click={() => {
-										showPreferencesModal = true;
+										$showPreferences = true;
 									}}
 									bind:disabled={preferencesModalRequestInFlight}
 								>


### PR DESCRIPTION
- check that the editor is running before swapping target branches
- only look at modified files for determining upstream conflicts. this is a little spicy but ultimately the command we were using no longer detects paths accurately because your pull might be a rebase with previously applied commits.
- add some clearer error handling to the preferences modal