### PR TITLE
chore(friendshipper): remove extra status calls from submit flow

### DIFF
--- a/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
+++ b/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
@@ -208,11 +208,15 @@
 				(file) => !changeSet.files.some((csFile) => csFile.path === file.path)
 			);
 		} else {
-			// avoid duplicates
+			// avoid duplicates and files that don't match the current search input
 			selectedFiles = [
 				...selectedFiles,
 				...changeSet.files.filter(
-					(file) => !selectedFiles.some((selectedFile) => selectedFile.path === file.path)
+					(file) =>
+						!selectedFiles.some((selectedFile) => selectedFile.path === file.path) &&
+						(searchInput.length < 3 ||
+							file.path.toLowerCase().includes(searchInput.toLowerCase()) ||
+							file.displayName.toLowerCase().includes(searchInput.toLowerCase()))
 				)
 			];
 		}
@@ -424,7 +428,10 @@
 	class="w-full relative p-4 sm:p-4 max-w-full bg-secondary-700 dark:bg-space-900 h-full overflow-y-hidden border-0 shadow-none"
 >
 	<div class="flex justify-between items-center gap-2 pb-2">
-		<h3 class="text-primary-400 text-xl">Modified Files</h3>
+		<div class="flex gap-2 items-center">
+			<h3 class="text-primary-400 text-xl">Modified Files</h3>
+			<span class="text-xs text-gray-400 font-italic">({selectedFiles.length} selected)</span>
+		</div>
 		<div class="flex gap-2">
 			{#if lockSelectedEnabled}
 				<Button
@@ -475,7 +482,7 @@
 							on:keydown={async (e) => {
 								if (e.key === 'Enter') {
 									changeSets[editingChangeSetIndex] = {
-										...changeSet,
+										...changeSets[editingChangeSetIndex],
 										name: editingChangeSetValue
 									};
 									editingChangeSetIndex = -1;
@@ -496,7 +503,7 @@
 									on:click={() => {
 										handleToggleAllFilesInChangeset(index);
 										changeSets[index] = {
-											...changeSet,
+											...changeSets[index],
 											checked: isChecked(changeSet.files),
 											indeterminate: isIndeterminate(changeSet.files)
 										};

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -8,7 +8,6 @@ use tracing::{info, instrument, warn};
 
 use crate::engine::CommunicationType;
 use crate::engine::EngineProvider;
-use crate::repo::operations::StatusOp;
 use crate::repo::RepoStatusRef;
 use crate::state::AppState;
 use ethos_core::clients::git;
@@ -411,20 +410,6 @@ where
             f11r_branch.clone_from(&prev_branch);
         }
 
-        let status_op = StatusOp {
-            repo_status: self.repo_status.clone(),
-            app_config: self.app_config.clone(),
-            repo_config: self.repo_config.clone(),
-            engine: self.engine.clone(),
-            git_client: self.git_client.clone(),
-            github_username: self.github_client.username.clone(),
-            aws_client: None,
-            storage: None,
-            allow_offline_communication: false,
-            skip_display_names: true,
-            skip_engine_update: false,
-        };
-
         // commit changes
         {
             let add_op = AddOp {
@@ -472,10 +457,6 @@ where
 
             // push up the branch - this way the commit's files are saved to the remote
             self.git_client.push(&f11r_branch).await?;
-
-            // update status now that the files have been committed and there aren't any more
-            // staged files
-            status_op.execute().await?;
         }
 
         if is_quicksubmit_branch(&prev_branch) {

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -8,6 +8,7 @@ use tracing::{info, instrument, warn};
 
 use crate::engine::CommunicationType;
 use crate::engine::EngineProvider;
+use crate::repo::operations::StatusOp;
 use crate::repo::RepoStatusRef;
 use crate::state::AppState;
 use ethos_core::clients::git;
@@ -212,6 +213,26 @@ where
         if self.files.is_empty() {
             return Err(CoreError::Input(anyhow!("No files to submit")));
         }
+
+        let status_op = StatusOp {
+            repo_status: self.repo_status.clone(),
+            app_config: self.app_config.clone(),
+            repo_config: self.repo_config.clone(),
+            engine: self.engine.clone(),
+            git_client: self.git_client.clone(),
+            github_username: self.github_client.username.clone(),
+            aws_client: None,
+            storage: None,
+            allow_offline_communication: false,
+            skip_display_names: true,
+
+            // we'll make sure this gets done at the end
+            skip_engine_update: true,
+        };
+
+        // We're moving this call from the frontend to the backend so we can customize
+        // some submit-specific behavior.
+        status_op.execute().await?;
 
         // abort if we are trying to submit any conflicted files, or files that should be locked, but aren't
         {

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -146,7 +146,7 @@
 	let accessToken: string | null = null;
 	let refreshToken: string | null = null;
 
-	const refreshInterval = 30 * 1000;
+	const refreshInterval = 60 * 1000;
 
 	let loading = false;
 	const loadingText = 'Refreshing data...';

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -146,7 +146,7 @@
 	let accessToken: string | null = null;
 	let refreshToken: string | null = null;
 
-	const refreshInterval = 60 * 1000;
+	const refreshInterval = 30 * 1000;
 
 	let loading = false;
 	const loadingText = 'Refreshing data...';

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -435,6 +435,7 @@
 		}
 
 		// refresh files after quick submit, whether it was successful or not
+		progressModalTitle = 'Refreshing files';
 		await refreshFiles(true);
 
 		showProgressModal = false;

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -393,8 +393,6 @@
 		showProgressModal = true;
 		progressModalTitle = 'Opening pull request';
 
-		await refreshFiles(false);
-
 		const message = get(commitMessage);
 
 		const req: PushRequest = {


### PR DESCRIPTION
This speeds up some of the status calls during the submit flow and fixes a few changeset selection/refresh bugs.