### PR TITLE
fix(server): bump f11r-server rust version

### DIFF
--- a/friendshipper/server/Dockerfile
+++ b/friendshipper/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 WORKDIR /app
 COPY . .
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
RustCrypto bumped MSRV to 1.85, so moving to current