### PR TITLE
feat(friendshipper): new button to launch without server for playtests

### DIFF
--- a/core/src/types/builds.rs
+++ b/core/src/types/builds.rs
@@ -16,4 +16,5 @@ pub struct SyncClientRequest {
 #[serde(rename_all = "camelCase")]
 pub struct LaunchOptions {
     pub name: String,
+    pub launch_without_server: bool,
 }

--- a/core/src/types/builds.rs
+++ b/core/src/types/builds.rs
@@ -14,7 +14,14 @@ pub struct SyncClientRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub enum LaunchMode {
+    WithServer,
+    WithoutServer,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LaunchOptions {
     pub name: String,
-    pub launch_without_server: bool,
+    pub launch_mode: LaunchMode,
 }

--- a/friendshipper/src-tauri/src/builds/router.rs
+++ b/friendshipper/src-tauri/src/builds/router.rs
@@ -294,73 +294,84 @@ where
     T::post_download(&local_path).await;
 
     if let Some(launch_options) = payload.launch_options {
-        let kube_client = ensure_kube_client(state.kube_client.read().clone())?;
-        let game_server = kube_client.get_gameserver(&launch_options.name).await?;
+        if !launch_options.name.is_empty() {
+            let kube_client = ensure_kube_client(state.kube_client.read().clone())?;
+            let game_server = kube_client.get_gameserver(&launch_options.name).await?;
 
-        if let Some(status) = game_server.status {
-            info!(
-                "Launching game client with server host {:?}:{}",
-                status.ip, status.port
-            );
+            if let Some(status) = game_server.status {
+                info!(
+                    "Launching game client with server host {:?}:{}",
+                    status.ip, status.port
+                );
 
-            // Assume this GameServerResults type will become an engine-specific type in the future.
-            // Right now, we're asking the client to basically look up game servers, then send us back
-            // the IP, port, and netimgui port, and that seems inefficient. We should be able to have the client
-            // send us a unique identifier for the server, and then we can call a generic GameServer -> LaunchConfig
-            // style method.
-            let game_server_results = GameServerResults {
-                // these fields don't matter
-                name: "".to_string(),
-                display_name: "".to_string(),
-                version: "".to_string(),
-                creation_timestamp: Time(Utc::now()),
+                // Assume this GameServerResults type will become an engine-specific type in the future.
+                // Right now, we're asking the client to basically look up game servers, then send us back
+                // the IP, port, and netimgui port, and that seems inefficient. We should be able to have the client
+                // send us a unique identifier for the server, and then we can call a generic GameServer -> LaunchConfig
+                // style method.
+                let game_server_results = GameServerResults {
+                    // these fields don't matter
+                    name: "".to_string(),
+                    display_name: "".to_string(),
+                    version: "".to_string(),
+                    creation_timestamp: Time(Utc::now()),
 
-                // these fields matter
-                ip: status.ip,
-                port: status.port,
-                netimgui_port: status.netimgui_port,
-                ready: status.ready.unwrap_or(false),
-            };
+                    // these fields matter
+                    ip: status.ip,
+                    port: status.port,
+                    netimgui_port: status.netimgui_port,
+                    ready: status.ready.unwrap_or(false),
+                };
 
-            let args = state.engine.create_launch_args(
-                state.app_config.read().clone(),
-                state.repo_config.read().clone(),
-                game_server_results,
-            );
-            let child = match state.engine.launch(local_path, args) {
-                Ok(child) => child,
+                let args = state.engine.create_launch_args(
+                    state.app_config.read().clone(),
+                    state.repo_config.read().clone(),
+                    game_server_results,
+                );
+                let child = match state.engine.launch(local_path, args) {
+                    Ok(child) => child,
+                    Err(e) => {
+                        error!("Failed to launch game client with error: {}", e);
+                        return Err(CoreError::Internal(e));
+                    }
+                };
+
+                if let Some(mut child) = child {
+                    if state.app_config.read().record_play {
+                        let client = obs::Client::default();
+                        match client.start_recording().await {
+                            Ok(_) => {}
+                            Err(e) => {
+                                return Err(e);
+                            }
+                        };
+
+                        tokio::spawn(async move {
+                            match child.wait() {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    error!("Error waiting for child: {}", e);
+                                }
+                            }
+                            match client.stop_recording().await {
+                                Ok(_) => {}
+                                Err(_) => {
+                                    error!("Error stopping recording");
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+        } else if launch_options.launch_without_server {
+            let empty_args: Vec<String> = Vec::new();
+            let _child = match state.engine.launch(local_path, empty_args) {
+                Ok(_child) => _child,
                 Err(e) => {
                     error!("Failed to launch game client with error: {}", e);
                     return Err(CoreError::Internal(e));
                 }
             };
-
-            if let Some(mut child) = child {
-                if state.app_config.read().record_play {
-                    let client = obs::Client::default();
-                    match client.start_recording().await {
-                        Ok(_) => {}
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    };
-
-                    tokio::spawn(async move {
-                        match child.wait() {
-                            Ok(_) => {}
-                            Err(e) => {
-                                error!("Error waiting for child: {}", e);
-                            }
-                        }
-                        match client.stop_recording().await {
-                            Ok(_) => {}
-                            Err(_) => {
-                                error!("Error stopping recording");
-                            }
-                        }
-                    });
-                }
-            }
         }
     }
 

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -192,7 +192,8 @@
 			artifactEntry: entry,
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
-				name: server.name
+				name: server.name,
+				launchWithoutServer: false
 			}
 		};
 

--- a/friendshipper/src/lib/components/home/ContributorLayout.svelte
+++ b/friendshipper/src/lib/components/home/ContributorLayout.svelte
@@ -26,6 +26,7 @@
 		Commit,
 		SyncClientRequest
 	} from '$lib/types';
+	import { LaunchMode } from '$lib/types';
 	import PlaytestCard from '$lib/components/playtests/PlaytestCard.svelte';
 	import {
 		allModifiedFiles,
@@ -193,7 +194,7 @@
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
 				name: server.name,
-				launchWithoutServer: false
+				launchMode: LaunchMode.WithServer
 			}
 		};
 

--- a/friendshipper/src/lib/components/home/PlaytestLayout.svelte
+++ b/friendshipper/src/lib/components/home/PlaytestLayout.svelte
@@ -156,7 +156,8 @@
 			artifactEntry: entry,
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
-				name: server.name
+				name: server.name,
+				launchWithoutServer: false
 			}
 		};
 

--- a/friendshipper/src/lib/components/home/PlaytestLayout.svelte
+++ b/friendshipper/src/lib/components/home/PlaytestLayout.svelte
@@ -28,6 +28,7 @@
 		SyncClientRequest,
 		TauriError
 	} from '$lib/types';
+	import { LaunchMode } from '$lib/types';
 	import { getServers, launchServer, openLogsFolder } from '$lib/gameServers';
 	import { syncClient, getBuilds, getBuild, cancelDownload } from '$lib/builds';
 	import ServerModal from '$lib/components/servers/ServerModal.svelte';
@@ -157,7 +158,7 @@
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
 				name: server.name,
-				launchWithoutServer: false
+				launchMode: LaunchMode.WithServer
 			}
 		};
 

--- a/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestCard.svelte
@@ -20,6 +20,7 @@
 		Playtest,
 		SyncClientRequest
 	} from '$lib/types';
+	import { LaunchMode } from '$lib/types';
 	import Countdown from '$lib/components/playtests/Countdown.svelte';
 	import {
 		assignUserToGroup,
@@ -129,7 +130,7 @@
 		if (server) {
 			req.launchOptions = {
 				name: server.name,
-				launchWithoutServer: false
+				launchMode: LaunchMode.WithServer
 			};
 		} else {
 			// this is a sync only, run it in the background
@@ -232,7 +233,7 @@
 						methodPrefix: $builds.methodPrefix,
 						launchOptions: {
 							name: '',
-							launchWithoutServer: true
+							launchMode: LaunchMode.WithoutServer
 						}
 					};
 

--- a/friendshipper/src/lib/components/servers/ServerModal.svelte
+++ b/friendshipper/src/lib/components/servers/ServerModal.svelte
@@ -82,7 +82,8 @@
 			artifactEntry: entry,
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
-				name: server.name
+				name: server.name,
+				launchWithoutServer: false
 			}
 		};
 

--- a/friendshipper/src/lib/components/servers/ServerModal.svelte
+++ b/friendshipper/src/lib/components/servers/ServerModal.svelte
@@ -12,6 +12,7 @@
 		SyncClientRequest,
 		PlaytestProfile
 	} from '$lib/types';
+	import { LaunchMode } from '$lib/types';
 	import {
 		activeProjectConfig,
 		repoConfig,
@@ -83,7 +84,7 @@
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
 				name: server.name,
-				launchWithoutServer: false
+				launchMode: LaunchMode.WithServer
 			}
 		};
 

--- a/friendshipper/src/lib/components/servers/ServerTable.svelte
+++ b/friendshipper/src/lib/components/servers/ServerTable.svelte
@@ -19,6 +19,7 @@
 	import { emit } from '@tauri-apps/api/event';
 	import { ProgressModal } from '@ethos/core';
 	import type { GameServerResult, SyncClientRequest } from '$lib/types';
+	import { LaunchMode } from '$lib/types';
 	import { appConfig, backgroundSyncInProgress, builds, dynamicConfig } from '$lib/stores';
 	import { syncClient } from '$lib/builds';
 	import {
@@ -66,7 +67,7 @@
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
 				name: server.name,
-				launchWithoutServer: false
+				launchMode: LaunchMode.WithServer
 			}
 		};
 

--- a/friendshipper/src/lib/components/servers/ServerTable.svelte
+++ b/friendshipper/src/lib/components/servers/ServerTable.svelte
@@ -65,7 +65,8 @@
 			artifactEntry: entry,
 			methodPrefix: $builds.methodPrefix,
 			launchOptions: {
-				name: server.name
+				name: server.name,
+				launchWithoutServer: false
 			}
 		};
 

--- a/friendshipper/src/lib/stores.ts
+++ b/friendshipper/src/lib/stores.ts
@@ -37,7 +37,30 @@ export const onboardingInProgress = writable(false);
 export const changeSets = writable(<ChangeSet[]>[]);
 export const startTime = writable(Date.now());
 export const backgroundSyncInProgress = writable(false);
-export const currentSyncedVersion = writable('');
+function createCurrentSyncedVersion() {
+	const { subscribe, set, update } = writable('');
+
+	return {
+		subscribe,
+		set: (value: string) => {
+			if (typeof window !== 'undefined') {
+				localStorage.setItem('currentSyncedVersion', value);
+			}
+			set(value);
+		},
+		update,
+		initialize: () => {
+			if (typeof window !== 'undefined') {
+				const stored = localStorage.getItem('currentSyncedVersion');
+				if (stored) {
+					set(stored);
+				}
+			}
+		}
+	};
+}
+
+export const currentSyncedVersion = createCurrentSyncedVersion();
 export const showPreferences = writable(false);
 
 export const nextPlaytest = derived([playtests, appConfig], ([$playtests, $appConfig]) => {

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -136,9 +136,14 @@ export interface ArtifactListResponse {
 	entries: ArtifactEntry[];
 }
 
+export enum LaunchMode {
+	WithServer = 'withServer',
+	WithoutServer = 'withoutServer'
+}
+
 export interface LaunchOptions {
 	name: string;
-	launchWithoutServer: bool;
+	launchMode: LaunchMode;
 }
 
 export interface SyncClientRequest {

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -138,6 +138,7 @@ export interface ArtifactListResponse {
 
 export interface LaunchOptions {
 	name: string;
+	launchWithoutServer: bool;
 }
 
 export interface SyncClientRequest {

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -52,6 +52,7 @@
 		builds,
 		changeSets,
 		commits,
+		currentSyncedVersion,
 		dynamicConfig,
 		engineWorkflows,
 		oktaAuth,
@@ -475,6 +476,9 @@
 
 		if (accessToken || $appConfig.serverless) {
 			try {
+				// Initialize the current synced version from localStorage
+				currentSyncedVersion.initialize();
+
 				const [dynamicConfigResponse, projectConfigResponse, buildsResponse] = await Promise.all([
 					getDynamicConfig(),
 					getProjectConfig(),


### PR DESCRIPTION
2 things:
* Fixed a bug with Friendshipper not detecting you have the client already synced for a build until you click sync at least once
* Added a new button that will launch the client without a server to the playtest card