### PR TITLE
fix(friendshipper): inverted pause broke git maintenance leading to b…

### DIFF
--- a/core/src/clients/git_maintenance_runner.rs
+++ b/core/src/clients/git_maintenance_runner.rs
@@ -77,7 +77,7 @@ impl GitMaintenanceRunner {
         let pause = self.pause.clone();
         let maintenance_task = tokio::task::spawn(async move {
             loop {
-                if pause.clone().load(std::sync::atomic::Ordering::Relaxed) {
+                if !pause.clone().load(std::sync::atomic::Ordering::Relaxed) {
                     match git.run_maintenance().await {
                         Ok(_) => {
                             info!("Maintenance complete");


### PR DESCRIPTION
…loated git objects & packs

Due to an inadvertant inversion, our automatic maintenance has been broken and not running for about a year in repos.  flipping this turns them back on when we're not paused. @rudoi perhaps you can validate this as it looks like it changed in this PR that you made? https://github.com/believer-oss/ethos/pull/242/files
