### PR TITLE
fix(friendshipper): fix setup using partial clone and auto-refetch if…

### DIFF
--- a/friendshipper/src-tauri/src/repo/operations/clone.rs
+++ b/friendshipper/src-tauri/src/repo/operations/clone.rs
@@ -80,13 +80,7 @@ where
     state
         .git()
         .run(
-            &[
-                "clone",
-                "--filter=tree:0",
-                "--progress",
-                &request.url,
-                repo_path_str,
-            ],
+            &["clone", "--progress", &request.url, repo_path_str],
             Default::default(),
         )
         .await?;


### PR DESCRIPTION
… user has a partial clone

Shallow clones make the repo download a ton of date for history and diff checks in the editor. these histories should always be local for quick diffing and availability to our tooling.  