### PR TITLE
feat(friendshipper): harden github request handling + github status to the Diagnostics page

### DIFF
--- a/core/src/clients/github.rs
+++ b/core/src/clients/github.rs
@@ -18,12 +18,96 @@ use crate::types::github::pulls::{
 use crate::types::github::user::{get_username, GetUsername};
 use anyhow::{anyhow, Result};
 use graphql_client::reqwest::post_graphql;
+use graphql_client::{GraphQLQuery, Response};
+use rand::Rng;
 use reqwest::Client;
 use std::collections::HashMap;
-use tracing::error;
-use tracing::instrument;
+use std::time::{Duration, Instant};
+use tracing::{error, instrument, warn};
 
 pub const GITHUB_GRAPHQL_URL: &str = "https://api.github.com/graphql";
+
+const RETRY_DEFAULT_ATTEMPTS: u32 = 3;
+const RETRY_NO_RETRY_ATTEMPTS: u32 = 1;
+const RETRY_BASE_DELAY_MS: u64 = 500;
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+const SLOW_CALL_WARN_SECS: u64 = 20;
+
+fn is_transient_transport_error(e: &reqwest::Error) -> bool {
+    // graphql_client::reqwest::post_graphql does not call error_for_status, so 5xx and
+    // 429 responses surface either as a successful Response with errors[] populated or,
+    // when the body is HTML (Cloudflare/Varnish error pages), as a JSON decode error.
+    // is_decode() therefore covers the practical 5xx/429 cases.
+    e.is_timeout() || e.is_connect() || e.is_decode()
+}
+
+async fn post_graphql_with_retry<Q>(
+    client: &Client,
+    op: &'static str,
+    max_attempts: u32,
+    mut variables: impl FnMut() -> Q::Variables,
+) -> Result<Response<Q::ResponseData>, reqwest::Error>
+where
+    Q: GraphQLQuery,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let started = Instant::now();
+        let res = post_graphql::<Q, _>(client, GITHUB_GRAPHQL_URL, variables()).await;
+        let elapsed = started.elapsed();
+        if elapsed >= Duration::from_secs(SLOW_CALL_WARN_SECS) {
+            warn!(
+                "{op} attempt {attempt} took {elapsed:?} (approaching {REQUEST_TIMEOUT_SECS}s timeout)"
+            );
+        }
+        let retry_reason: Option<String> = match &res {
+            Ok(response)
+                if response.data.is_none()
+                    && response.errors.as_ref().is_none_or(|e| e.is_empty()) =>
+            {
+                Some("empty GraphQL response (likely transient GitHub outage)".to_string())
+            }
+            Err(e) if is_transient_transport_error(e) => Some(e.to_string()),
+            _ => None,
+        };
+        match retry_reason {
+            Some(reason) if attempt < max_attempts => {
+                let base_ms = RETRY_BASE_DELAY_MS
+                    .checked_shl(attempt - 1)
+                    .unwrap_or(u64::MAX);
+                // ±25% jitter centered on the nominal backoff to avoid thundering herds.
+                let jitter_factor: f64 = rand::thread_rng().gen_range(0.75..=1.25);
+                let delay = Duration::from_millis((base_ms as f64 * jitter_factor) as u64);
+                warn!(
+                    "{op} attempt {attempt}/{max_attempts} failed: {reason}; retrying in {delay:?}"
+                );
+                tokio::time::sleep(delay).await;
+            }
+            _ => return res,
+        }
+    }
+}
+
+#[track_caller]
+fn missing_data_error<T: std::fmt::Debug>(op: &str, res: &Response<T>) -> anyhow::Error {
+    let caller = std::panic::Location::caller();
+    let errors_msg = res
+        .errors
+        .as_ref()
+        .filter(|errs| !errs.is_empty())
+        .map(|errs| {
+            errs.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        })
+        .unwrap_or_else(|| "no errors returned (likely a transient GitHub outage)".to_string());
+    error!(
+        "GraphQL response missing data for {op} at {caller}: errors=[{errors_msg}], response={res:?}"
+    );
+    anyhow!("Failed to get valid response data for {op}: {errors_msg}")
+}
 
 #[derive(Debug, Clone)]
 pub struct GraphQLClient {
@@ -39,6 +123,8 @@ impl GraphQLClient {
     pub async fn new(token: String) -> Result<Self> {
         let client = Client::builder()
             .user_agent("graphql-rust/0.10.0")
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .connect_timeout(Duration::from_secs(10))
             .default_headers(
                 std::iter::once((
                     reqwest::header::AUTHORIZATION,
@@ -48,10 +134,11 @@ impl GraphQLClient {
             )
             .build()?;
 
-        match post_graphql::<GetUsername, _>(
+        match post_graphql_with_retry::<GetUsername>(
             &client,
-            GITHUB_GRAPHQL_URL,
-            get_username::Variables {},
+            "get_username",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_username::Variables {},
         )
         .await
         {
@@ -73,12 +160,13 @@ impl GraphQLClient {
         repo: String,
         number: i64,
     ) -> Result<String> {
-        let res = match post_graphql::<GetPullRequestId, _>(
+        let res = match post_graphql_with_retry::<GetPullRequestId>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_pull_request_id::Variables {
-                owner: owner.clone().to_string(),
-                name: repo.clone().to_string(),
+            "get_pull_request_id",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_pull_request_id::Variables {
+                owner: owner.clone(),
+                name: repo.clone(),
                 number,
             },
         )
@@ -93,10 +181,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_pull_request_id", &res)),
         };
 
         let repo = match &data.repository {
@@ -125,12 +210,13 @@ impl GraphQLClient {
         repo: String,
         number: i64,
     ) -> Result<GetPullRequestRepositoryPullRequest> {
-        let res = match post_graphql::<GetPullRequest, _>(
+        let res = match post_graphql_with_retry::<GetPullRequest>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_pull_request::Variables {
-                owner: owner.clone().to_string(),
-                name: repo.clone().to_string(),
+            "get_pull_request",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_pull_request::Variables {
+                owner: owner.clone(),
+                name: repo.clone(),
                 number,
             },
         )
@@ -145,10 +231,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_pull_request", &res)),
         };
 
         let repo = match &data.repository {
@@ -178,10 +261,14 @@ impl GraphQLClient {
         limit: i64,
     ) -> Result<Vec<GetPullRequestsSearchEdgesNodeOnPullRequest>> {
         let query = format!("is:pr author:{} repo:{}/{}", self.username, owner, repo);
-        let res = match post_graphql::<GetPullRequests, _>(
+        let res = match post_graphql_with_retry::<GetPullRequests>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_pull_requests::Variables { query, limit },
+            "get_pull_requests",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_pull_requests::Variables {
+                query: query.clone(),
+                limit,
+            },
         )
         .await
         {
@@ -194,10 +281,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_pull_requests", &res)),
         };
 
         let search_edges = match data.search.edges {
@@ -256,10 +340,11 @@ impl GraphQLClient {
         branch: &str,
         limit: i64,
     ) -> Result<bool> {
-        let res = match post_graphql::<IsBranchPrOpen, _>(
+        let res = match post_graphql_with_retry::<IsBranchPrOpen>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            is_branch_pr_open::Variables {
+            "is_branch_pr_open",
+            RETRY_DEFAULT_ATTEMPTS,
+            || is_branch_pr_open::Variables {
                 owner: owner.to_string(),
                 name: repo.to_string(),
                 branch: branch.to_string(),
@@ -277,10 +362,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("is_branch_pr_open", &res)),
         };
 
         let repo = match &data.repository {
@@ -308,10 +390,33 @@ impl GraphQLClient {
         owner: &str,
         repo: &str,
     ) -> Result<GetMergeQueueRepositoryMergeQueue> {
-        let res = match post_graphql::<GetMergeQueue, _>(
+        self.get_merge_queue_inner(owner, repo, RETRY_DEFAULT_ATTEMPTS)
+            .await
+    }
+
+    /// Fail-fast variant of `get_merge_queue` used in interactive paths (e.g. submit)
+    /// where waiting through the full retry budget would feel like a hang to the user.
+    #[instrument(skip(self))]
+    pub async fn get_merge_queue_no_retry(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<GetMergeQueueRepositoryMergeQueue> {
+        self.get_merge_queue_inner(owner, repo, RETRY_NO_RETRY_ATTEMPTS)
+            .await
+    }
+
+    async fn get_merge_queue_inner(
+        &self,
+        owner: &str,
+        repo: &str,
+        max_attempts: u32,
+    ) -> Result<GetMergeQueueRepositoryMergeQueue> {
+        let res = match post_graphql_with_retry::<GetMergeQueue>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_merge_queue::Variables {
+            "get_merge_queue",
+            max_attempts,
+            || get_merge_queue::Variables {
                 owner: owner.to_string(),
                 name: repo.to_string(),
             },
@@ -327,10 +432,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_merge_queue", &res)),
         };
 
         let repo = match &data.repository {
@@ -359,10 +461,11 @@ impl GraphQLClient {
         repo: &str,
         limit: i64,
     ) -> Result<CommitStatusMap> {
-        let res = match post_graphql::<GetCommitStatuses, _>(
+        let res = match post_graphql_with_retry::<GetCommitStatuses>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_commit_statuses::Variables {
+            "get_commit_statuses",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_commit_statuses::Variables {
                 owner: owner.to_string(),
                 name: repo.to_string(),
                 limit,
@@ -379,10 +482,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_commit_statuses", &res)),
         };
 
         let repo = match &data.repository {
@@ -458,10 +558,11 @@ impl GraphQLClient {
         branch: &str,
         limit: i64,
     ) -> Result<MergeTimestampMap> {
-        let res = match post_graphql::<GetCommitMergeTimestamps, _>(
+        let res = match post_graphql_with_retry::<GetCommitMergeTimestamps>(
             &self.client,
-            GITHUB_GRAPHQL_URL,
-            get_commit_merge_timestamps::Variables {
+            "get_commit_merge_timestamps",
+            RETRY_DEFAULT_ATTEMPTS,
+            || get_commit_merge_timestamps::Variables {
                 owner: owner.to_string(),
                 name: repo.to_string(),
                 qualified_name: branch.to_string(),
@@ -479,10 +580,7 @@ impl GraphQLClient {
 
         let data = match res.data {
             Some(data) => data,
-            None => {
-                error!("Response data was empty: {:?}", res);
-                return Err(anyhow!("Failed to get valid response data"));
-            }
+            None => return Err(missing_data_error("get_commit_merge_timestamps", &res)),
         };
 
         let repo = match &data.repository {

--- a/core/src/clients/github.rs
+++ b/core/src/clients/github.rs
@@ -134,10 +134,12 @@ impl GraphQLClient {
             )
             .build()?;
 
+        // PAT validation is interactive (user is waiting on the settings save) and a bad
+        // PAT is a permanent error, so don't burn the retry budget here — fail fast.
         match post_graphql_with_retry::<GetUsername>(
             &client,
             "get_username",
-            RETRY_DEFAULT_ATTEMPTS,
+            RETRY_NO_RETRY_ATTEMPTS,
             || get_username::Variables {},
         )
         .await

--- a/core/src/types/github/mod.rs
+++ b/core/src/types/github/mod.rs
@@ -4,6 +4,7 @@ use axum::response::{IntoResponse, Response};
 pub mod commits;
 pub mod merge_queue;
 pub mod pulls;
+pub mod status;
 pub mod user;
 
 #[derive(Debug)]

--- a/core/src/types/github/status.rs
+++ b/core/src/types/github/status.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubStatusResponse {
+    /// Statuspage indicator: "none", "minor", "major", "critical", or "maintenance".
+    pub indicator: String,
+    /// Human-readable status, e.g. "All Systems Operational".
+    pub description: String,
+    /// Link to the public GitHub status page.
+    pub url: String,
+}

--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -97,6 +97,26 @@ pub async fn run_git_gc(state: tauri::State<'_, State>) -> Result<(), TauriError
     Ok(())
 }
 
+#[tauri::command]
+pub async fn get_github_status(
+    state: tauri::State<'_, State>,
+) -> Result<ethos_core::types::github::status::GitHubStatusResponse, TauriError> {
+    let res = state
+        .client
+        .get(format!(
+            "{}/repo/diagnostics/github-status",
+            state.server_url
+        ))
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    Ok(res.json().await?)
+}
+
 // Config
 #[tauri::command]
 pub async fn get_dynamic_config(

--- a/friendshipper/src-tauri/src/main.rs
+++ b/friendshipper/src-tauri/src/main.rs
@@ -230,6 +230,7 @@ fn main() -> Result<(), CoreError> {
                 open_terminal_to_path,
                 get_unrealversionselector_status,
                 get_object_count,
+                get_github_status,
                 run_git_gc,
                 open_url,
                 quick_submit,

--- a/friendshipper/src-tauri/src/repo/operations/diagnostics/github_status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/diagnostics/github_status.rs
@@ -1,0 +1,44 @@
+use anyhow::anyhow;
+use axum::Json;
+use serde::Deserialize;
+use std::time::Duration;
+
+use ethos_core::types::errors::CoreError;
+use ethos_core::types::github::status::GitHubStatusResponse;
+
+const GITHUB_STATUS_URL: &str = "https://www.githubstatus.com/api/v2/status.json";
+const GITHUB_STATUS_PAGE_URL: &str = "https://www.githubstatus.com";
+
+#[derive(Deserialize)]
+struct StatuspageResponse {
+    status: StatuspageStatus,
+}
+
+#[derive(Deserialize)]
+struct StatuspageStatus {
+    indicator: String,
+    description: String,
+}
+
+pub async fn github_status_handler() -> Result<Json<GitHubStatusResponse>, CoreError> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to build status client: {}", e)))?;
+
+    let resp =
+        client.get(GITHUB_STATUS_URL).send().await.map_err(|e| {
+            CoreError::Internal(anyhow!("Failed to reach GitHub status page: {}", e))
+        })?;
+
+    let body: StatuspageResponse = resp.json().await.map_err(|e| {
+        CoreError::Internal(anyhow!("Failed to parse GitHub status response: {}", e))
+    })?;
+
+    Ok(Json(GitHubStatusResponse {
+        indicator: body.status.indicator,
+        description: body.status.description,
+        url: GITHUB_STATUS_PAGE_URL.to_string(),
+    }))
+}

--- a/friendshipper/src-tauri/src/repo/operations/diagnostics/mod.rs
+++ b/friendshipper/src-tauri/src/repo/operations/diagnostics/mod.rs
@@ -1,6 +1,8 @@
+mod github_status;
 mod object_count;
 mod rebase;
 
+pub use github_status::github_status_handler;
 pub use object_count::object_count_handler;
 pub use object_count::run_gc_handler;
 pub use rebase::rebase_handler;

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -458,7 +458,10 @@ where
                 return Err(CoreError::Internal(anyhow::anyhow!("Repository information not yet available - please wait for repo status to initialize")));
             }
 
-            let merge_queue = self.github_client.get_merge_queue(&owner, &repo).await?;
+            let merge_queue = self
+                .github_client
+                .get_merge_queue_no_retry(&owner, &repo)
+                .await?;
             if let Some(entries) = merge_queue.entries {
                 if let Some(nodes) = entries.nodes {
                     for node in nodes.into_iter().flatten() {

--- a/friendshipper/src-tauri/src/repo/router.rs
+++ b/friendshipper/src-tauri/src/repo/router.rs
@@ -45,6 +45,10 @@ where
             "/diagnostics/gc",
             post(operations::diagnostics::run_gc_handler),
         )
+        .route(
+            "/diagnostics/github-status",
+            get(operations::diagnostics::github_status_handler),
+        )
         .route("/download-dlls", post(operations::download_dlls_handler))
         .route("/reset-engine", post(operations::reset_engine_handler))
         .route("/download-engine", post(operations::update_engine_handler))

--- a/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
+++ b/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
@@ -235,90 +235,96 @@
 
 		const internal = async () => {
 			requestInFlight = true;
+			try {
+				progressModalTitle = 'Saving preferences...';
+				await saveChangeSet($changeSets);
 
-			progressModalTitle = 'Saving preferences...';
-			await saveChangeSet($changeSets);
+				// make sure maxClientCacheSizeGb is a number
+				localAppConfig.maxClientCacheSizeGb = Number(localAppConfig.maxClientCacheSizeGb);
 
-			// make sure maxClientCacheSizeGb is a number
-			localAppConfig.maxClientCacheSizeGb = Number(localAppConfig.maxClientCacheSizeGb);
+				const accessToken = $oktaAuth?.getAccessToken();
+				if (accessToken) {
+					await updateAppConfig(localAppConfig, accessToken, true);
+				} else {
+					throw new Error('Failed to save preferences. No access token found.');
+				}
 
-			const accessToken = $oktaAuth?.getAccessToken();
-			if (accessToken) {
-				await updateAppConfig(localAppConfig, accessToken, true);
-			} else {
-				await emit('error', 'Failed to save preferences. No access token found.');
+				const regionChanged = $appConfig.playtestRegion !== localAppConfig.playtestRegion;
+
+				try {
+					$appConfig = await getAppConfig();
+				} catch (e) {
+					await emit('error', e);
+				}
+
+				let playtestPromise: Nullable<Promise> = null;
+				let statusPromise: Nullable<Promise> = null;
+				let commitsPromise: Nullable<Promise> = null;
+				let workflowsPromise: Nullable<Promise> = null;
+
+				if (regionChanged) {
+					playtestPromise = getPlaytests();
+				}
+
+				if (hasTargetBranchChanged) {
+					await checkoutTargetBranch();
+					statusPromise = getRepoStatus();
+					commitsPromise = getAllCommits();
+				}
+
+				if (hasRepoUrlChanged) {
+					statusPromise = getRepoStatus();
+					commitsPromise = getAllCommits();
+
+					if (localAppConfig.repoUrl !== '') {
+						workflowsPromise = await getWorkflows();
+					}
+				}
+
+				const { playtestResponse, statusResponse, commitsResponse, workflowsResponse } =
+					await Promise.all([playtestPromise, statusPromise, commitsPromise, workflowsPromise]);
+
+				if (playtestResponse) {
+					playtests.set(playtestResponse);
+				}
+
+				if (statusResponse) {
+					repoStatus.set(statusResponse);
+				}
+
+				if (commitsResponse) {
+					commits.set(commitsResponse);
+				}
+
+				if (workflowsResponse) {
+					$engineWorkflows = workflowsResponse.commits;
+				}
+
+				$changeSets = await loadChangeSet();
+				void emit('preferences-closed');
+			} finally {
 				requestInFlight = false;
 			}
-
-			const regionChanged = $appConfig.playtestRegion !== localAppConfig.playtestRegion;
-
-			try {
-				$appConfig = await getAppConfig();
-			} catch (e) {
-				await emit('error', e);
-			}
-
-			let playtestPromise: Nullable<Promise> = null;
-			let statusPromise: Nullable<Promise> = null;
-			let commitsPromise: Nullable<Promise> = null;
-			let workflowsPromise: Nullable<Promise> = null;
-
-			if (regionChanged) {
-				playtestPromise = getPlaytests();
-			}
-
-			if (hasTargetBranchChanged) {
-				await checkoutTargetBranch();
-				statusPromise = getRepoStatus();
-				commitsPromise = getAllCommits();
-			}
-
-			if (hasRepoUrlChanged) {
-				statusPromise = getRepoStatus();
-				commitsPromise = getAllCommits();
-
-				if (localAppConfig.repoUrl !== '') {
-					workflowsPromise = await getWorkflows();
-				}
-			}
-
-			const { playtestResponse, statusResponse, commitsResponse, workflowsResponse } =
-				await Promise.all([playtestPromise, statusPromise, commitsPromise, workflowsPromise]);
-
-			if (playtestResponse) {
-				playtests.set(playtestResponse);
-			}
-
-			if (statusResponse) {
-				repoStatus.set(statusResponse);
-			}
-
-			if (commitsResponse) {
-				commits.set(commitsResponse);
-			}
-
-			if (workflowsResponse) {
-				$engineWorkflows = workflowsResponse.commits;
-			}
-
-			$changeSets = await loadChangeSet();
-			void emit('preferences-closed');
-			requestInFlight = false;
 		};
 
 		showModal = false;
 
-		await internal();
-		if (hasRepoUrlChanged || hasTargetBranchChanged) {
-			await restart();
+		try {
+			await internal();
+			if (hasRepoUrlChanged || hasTargetBranchChanged) {
+				await restart();
 
-			// wait 5 seconds before closing the modal
-			setTimeout(() => {
-				showProgressModal = false;
-			}, 5000);
+				// wait 5 seconds before closing the modal
+				setTimeout(() => {
+					showProgressModal = false;
+				}, 5000);
+			}
+		} catch (e) {
+			await emit('error', e);
+		} finally {
+			configuringNewRepo = false;
+			showProgressModal = false;
 		}
-		configuringNewRepo = false;
-		showProgressModal = false;
 	};
 
 	const onDiscardClicked = () => {

--- a/friendshipper/src/lib/repo.ts
+++ b/friendshipper/src/lib/repo.ts
@@ -5,6 +5,7 @@ import type {
 	CommitInfo,
 	FileHistoryResponse,
 	GitHubPullRequest,
+	GitHubStatusResponse,
 	MergeQueue,
 	ObjectCountResponse,
 	PushRequest,
@@ -146,6 +147,9 @@ export const fixRebase = async (): Promise<void> => invoke('fix_rebase');
 export const rebase = async (): Promise<void> => invoke('rebase');
 
 export const getObjectCount = async (): Promise<ObjectCountResponse> => invoke('get_object_count');
+
+export const getGithubStatus = async (): Promise<GitHubStatusResponse> =>
+	invoke('get_github_status');
 
 export const runGitGc = async (): Promise<void> => invoke('run_git_gc');
 

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -370,6 +370,12 @@ export interface ObjectCountResponse {
 	rawOutput: string;
 }
 
+export interface GitHubStatusResponse {
+	indicator: 'none' | 'minor' | 'major' | 'critical' | 'maintenance';
+	description: string;
+	url: string;
+}
+
 export interface Snapshot {
 	commit: string;
 	message: string;

--- a/friendshipper/src/routes/source/diagnostics/+page.svelte
+++ b/friendshipper/src/routes/source/diagnostics/+page.svelte
@@ -9,6 +9,7 @@
 	import { repoStatus } from '$lib/stores';
 	import {
 		fixRebase,
+		getGithubStatus,
 		getObjectCount,
 		getRebaseStatus,
 		getRepoStatus,
@@ -16,7 +17,12 @@
 		runGitGc
 	} from '$lib/repo';
 	import { getUnrealVersionSelectorStatus } from '$lib/system';
-	import { CheckStatus, type ObjectCountResponse, type RebaseStatusResponse } from '$lib/types';
+	import {
+		CheckStatus,
+		type GitHubStatusResponse,
+		type ObjectCountResponse,
+		type RebaseStatusResponse
+	} from '$lib/types';
 	import EmojiStatus from '$lib/components/EmojiStatus.svelte';
 
 	// Various check statuses
@@ -26,6 +32,8 @@
 	let rebaseRequiredCheck: CheckStatus = CheckStatus.Loading;
 	let objectCountCheck: CheckStatus = CheckStatus.Loading;
 	let unrealVersionSelectorCheck: CheckStatus = CheckStatus.Loading;
+	let githubStatusCheck: CheckStatus = CheckStatus.Loading;
+	let githubStatus: GitHubStatusResponse | null = null;
 
 	let loading = false;
 	let updatingRebaseStatus = false;
@@ -60,6 +68,7 @@
 		rebaseRequiredCheck = CheckStatus.Loading;
 		objectCountCheck = CheckStatus.Loading;
 		unrealVersionSelectorCheck = CheckStatus.Loading;
+		githubStatusCheck = CheckStatus.Loading;
 
 		try {
 			repoStatus.set(await getRepoStatus());
@@ -126,6 +135,16 @@
 		} catch (e) {
 			await emit('error', e);
 			unrealVersionSelectorCheck = CheckStatus.Failure;
+		}
+
+		try {
+			githubStatus = await getGithubStatus();
+			githubStatusCheck =
+				githubStatus.indicator === 'none' ? CheckStatus.Success : CheckStatus.Failure;
+		} catch (e) {
+			await emit('error', e);
+			githubStatus = null;
+			githubStatusCheck = CheckStatus.Failure;
 		}
 
 		updatingRebaseStatus = false;
@@ -353,6 +372,31 @@
 				/>
 			{:else}
 				Everything looks good!
+			{/if}
+		</AccordionItem>
+		<AccordionItem class="w-full">
+			<div slot="header" class="flex items-center justify-between w-full pr-2">
+				<div class="w-1/3">GitHub Status</div>
+				<span class="text-xs text-gray-300 font-mono w-3/4"
+					>Is GitHub reporting all systems operational?</span
+				>
+				<EmojiStatus checkStatus={githubStatusCheck} />
+			</div>
+			{#if githubStatus}
+				<div class="flex flex-col gap-1">
+					<span>
+						<span class="font-semibold">{githubStatus.description}</span>
+						<span class="text-xs text-gray-300">(indicator: {githubStatus.indicator})</span>
+					</span>
+					<a
+						class="text-xs text-primary-400 underline"
+						href={githubStatus.url}
+						target="_blank"
+						rel="noopener noreferrer">{githubStatus.url}</a
+					>
+				</div>
+			{:else}
+				Could not reach the GitHub status page.
 			{/if}
 		</AccordionItem>
 	</Accordion>


### PR DESCRIPTION
 Hardens the GitHub GraphQL client against transient outages (which have been happening more often) and adds a GitHub status indicator to the Diagnostics tab so users can self-triage.

  Changes

  Verbose error messages. "Failed to get valid response data" was a dead-end string. Errors now include the operation name and GitHub's actual errors[] content ("Bad credentials", "API rate limit exceeded", etc.), or label the empty-response
  case as a likely upstream outage.

  Request timeout. The client had no timeout configured at all — a hung connection during an outage could hang forever. Now 30s request / 10s connect, matching the other clients in the repo.

  Retry with backoff and jitter. New post_graphql_with_retry wrapper, applied to all read queries. Up to 3 attempts on
  transient transport errors (is_timeout / is_connect / is_decode) and on the application-layer "HTTP 200 + null data +
  empty errors[]" signature that GitHub serves during degraded windows. Exponential backoff with ±25% jitter to avoid
  thundering herds. Mutations are deliberately not retried.

  Fail-fast variant for submit. get_merge_queue_no_retry is used inside the merge-submit flow so a transient failure doesn't
   make the app appear hung for ~90s while the user is waiting on a click. Drops worst-case latency on that path from ~91s  to ~30s.

  Slow-call observability. Any GraphQL attempt that takes ≥20s logs a warn! so we have an actionable signal if the 30s   timeout turns out to be too tight for queries like get_commit_statuses(limit=100) on busy repos.

  GitHub Status indicator on Diagnostics tab. Calls the public Statuspage endpoint
  (https://www.githubstatus.com/api/v2/status.json) via a new /repo/diagnostics/github-status route + Tauri command. Renders  green when indicator === "none", red otherwise, with the description and a link to the status page. Uses a separate reqwest::Client so the GitHub PAT in the GraphQL client headers isn't leaked to a third-party domain.

  Why

  A coworker hit "Failed to get valid response data for get_pull_requests…: no errors returned" after booting up the  application during one of GitHub's recurring degraded windows. Investigating that one error surfaced three latent issues — opaque  error messages, no timeout, and no retry — all addressed here. The diagnostics indicator closes the loop so users don't have to ping the team to ask "is it just me?"

  Test plan

  - cargo check, cargo clippy -- -D warnings, cargo fmt --check, yarn run check all clean
  - Manual: open Diagnostics, confirm new "GitHub Status" entry renders green
  - Manual: revoke PAT and confirm the new error message includes "Bad credentials"
  - Manual: run a submit and confirm the merge-queue check still works through the no-retry path