### PR TITLE
feat(friendshipper): zip/import local changes with pre-import snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "winreg 0.51.0",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -8712,7 +8713,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -11491,6 +11492,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -358,7 +358,13 @@ impl Git {
                 }
 
                 let stash_index = parts[0].trim();
-                let message = parts[1].split(SNAPSHOT_PREFIX).collect::<Vec<_>>()[1].trim();
+                // Split only at the first occurrence so messages that themselves contain
+                // the word "snapshot" (e.g. "Auto-snapshot before importing X.zip") are
+                // preserved in full instead of being truncated at the embedded match.
+                let message = match parts[1].split_once(SNAPSHOT_PREFIX) {
+                    Some((_, m)) => m.trim(),
+                    None => return None,
+                };
                 let commit = parts[2].trim();
                 let date = parts[3].trim();
 
@@ -399,23 +405,52 @@ impl Git {
         self.wait_for_lock().await;
 
         if paths.is_empty() {
-            self.run(&["add", "--", "."], Opts::default()).await?;
+            self.run(&["add", "-A", "--", "."], Opts::default()).await?;
         } else {
-            let mut temp_file = NamedTempFile::new()?;
-            for path in &paths {
-                writeln!(temp_file, "{path}")?;
-            }
-            temp_file.flush()?;
+            // Split paths by working-tree presence. `git add <exact-path>` rejects paths
+            // whose file no longer exists on disk ("pathspec did not match any files"),
+            // even with `-A`, so we have to stage deletions via `git rm --cached`.
+            let (deleted_paths, existing_paths): (Vec<&String>, Vec<&String>) =
+                paths.iter().partition(|p| !self.repo_path.join(p).exists());
 
-            self.run(
-                &[
-                    "add",
-                    "--pathspec-from-file",
-                    temp_file.path().to_str().unwrap(),
-                ],
-                Opts::default(),
-            )
-            .await?;
+            if !existing_paths.is_empty() {
+                let mut add_temp = NamedTempFile::new()?;
+                for path in &existing_paths {
+                    writeln!(add_temp, "{path}")?;
+                }
+                add_temp.flush()?;
+                self.run(
+                    &[
+                        "add",
+                        "--pathspec-from-file",
+                        add_temp.path().to_str().unwrap(),
+                    ],
+                    Opts::default(),
+                )
+                .await?;
+            }
+
+            if !deleted_paths.is_empty() {
+                let mut rm_temp = NamedTempFile::new()?;
+                for path in &deleted_paths {
+                    writeln!(rm_temp, "{path}")?;
+                }
+                rm_temp.flush()?;
+                // `--cached` keeps git from trying to remove files from the working tree
+                // (they're already gone); `--ignore-unmatch` keeps the command from
+                // failing if a path happens to be missing from the index.
+                self.run(
+                    &[
+                        "rm",
+                        "--cached",
+                        "--ignore-unmatch",
+                        "--pathspec-from-file",
+                        rm_temp.path().to_str().unwrap(),
+                    ],
+                    Opts::default(),
+                )
+                .await?;
+            }
         }
 
         let stash_message = format!("{SNAPSHOT_PREFIX} {message}");

--- a/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
+++ b/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
@@ -2,6 +2,7 @@
 	import {
 		Alert,
 		Button,
+		ButtonGroup,
 		Card,
 		Checkbox,
 		Input,
@@ -539,25 +540,35 @@
 			<span class="text-xs text-gray-400 font-italic">({selectedFiles.length} selected)</span>
 		</div>
 		<div class="flex gap-2">
-			{#if lockSelectedEnabled}
+			<ButtonGroup size="xs" class="space-x-px">
+				{#if lockSelectedEnabled}
+					<Button
+						size="xs"
+						color="primary"
+						disabled={disabled || selectedFiles.length === 0}
+						on:click={onLockSelected}
+						>Lock Selected
+					</Button>
+				{/if}
 				<Button
 					size="xs"
+					color="primary"
 					disabled={disabled || selectedFiles.length === 0}
-					on:click={onLockSelected}
-					>Lock Selected
+					on:click={promptForRevertConfirmation}
+					>Revert Selected
 				</Button>
-			{/if}
-			<Button
-				size="xs"
-				disabled={disabled || selectedFiles.length === 0}
-				on:click={promptForRevertConfirmation}
-				>Revert Selected
-			</Button>
-			{#if snapshotsEnabled}
-				<Button size="xs" disabled={modifiedFiles.length === 0} on:click={onSaveSnapshot}
-					>Save Snapshot {selectedFiles.length > 0 ? `(${selectedFiles.length})` : '(all)'}
-				</Button>
-			{/if}
+				{#if snapshotsEnabled}
+					<Button
+						size="xs"
+						color="primary"
+						disabled={modifiedFiles.length === 0}
+						on:click={onSaveSnapshot}
+						>Save Snapshot {selectedFiles.length > 0 ? `(${selectedFiles.length})` : '(all)'}
+					</Button>
+				{/if}
+				<slot name="actions-dropdown-trigger" />
+			</ButtonGroup>
+			<slot name="actions-dropdown" />
 		</div>
 	</div>
 	<div class="flex gap-2 pb-1">

--- a/friendshipper/src-tauri/Cargo.toml
+++ b/friendshipper/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ obws = "0.11.5"
 k8s-openapi = { version = "0.20.0", features = ["v1_24"] }
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 futures = "0.3.30"
 serde-xml-rs = "0.6.0"
 dirs = "5.0.1"

--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -21,7 +21,8 @@ use ethos_core::types::repo::{
 };
 use friendshipper::builds::router::GetWorkflowsResponse;
 use friendshipper::repo::operations::{
-    RestoreFileToRevisionRequest, RestoreSnapshotRequest, SaveChangeSetRequest, SaveSnapshotRequest,
+    ImportZippedChangesRequest, RestoreFileToRevisionRequest, RestoreSnapshotRequest,
+    SaveChangeSetRequest, SaveSnapshotRequest, ZipLocalChangesRequest,
 };
 
 // Update the TauriError creation to include status_code
@@ -763,6 +764,68 @@ pub async fn load_changeset(state: tauri::State<'_, State>) -> Result<Vec<Change
     })?;
 
     Ok(json)
+}
+
+#[tauri::command]
+pub async fn zip_local_changes(
+    state: tauri::State<'_, State>,
+    files: Vec<String>,
+    destination: String,
+) -> Result<serde_json::Value, TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/repo/zip/local-changes", state.server_url))
+        .json(&ZipLocalChangesRequest { files, destination })
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    Ok(res.json().await?)
+}
+
+#[tauri::command]
+pub async fn preview_import_zip(
+    state: tauri::State<'_, State>,
+    source: String,
+) -> Result<serde_json::Value, TauriError> {
+    let encoded = urlencoding::encode(&source);
+    let res = state
+        .client
+        .get(format!(
+            "{}/repo/zip/import/preview?source={}",
+            state.server_url, encoded
+        ))
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    Ok(res.json().await?)
+}
+
+#[tauri::command]
+pub async fn import_zipped_changes(
+    state: tauri::State<'_, State>,
+    source: String,
+    files: Option<Vec<String>>,
+) -> Result<serde_json::Value, TauriError> {
+    let res = state
+        .client
+        .post(format!("{}/repo/zip/import", state.server_url))
+        .json(&ImportZippedChangesRequest { source, files })
+        .send()
+        .await?;
+
+    if is_error_status(res.status()) {
+        return Err(create_tauri_error(res).await);
+    }
+
+    Ok(res.json().await?)
 }
 
 #[tauri::command]

--- a/friendshipper/src-tauri/src/main.rs
+++ b/friendshipper/src-tauri/src/main.rs
@@ -279,6 +279,9 @@ fn main() -> Result<(), CoreError> {
                 update_playtest,
                 verify_build,
                 wipe_client_data,
+                zip_local_changes,
+                preview_import_zip,
+                import_zipped_changes,
                 exit_app,
             ])
             .setup(move |app| {

--- a/friendshipper/src-tauri/src/repo/operations/mod.rs
+++ b/friendshipper/src-tauri/src/repo/operations/mod.rs
@@ -24,6 +24,10 @@ pub use status::{status_handler, RepoStatusRef, StatusOp};
 pub use update_engine::{
     reset_engine_handler, update_engine_handler, UpdateEngineOp, WipeEngineOp,
 };
+pub use zip_changes::{
+    import_zipped_changes_handler, preview_import_zip_handler, zip_local_changes_handler,
+    ImportZippedChangesRequest, ZipLocalChangesRequest,
+};
 
 pub use crate::repo::operations::gh::submit::GitHubSubmitOp;
 
@@ -173,3 +177,4 @@ mod snapshot;
 mod status;
 mod update_engine;
 pub mod validate;
+mod zip_changes;

--- a/friendshipper/src-tauri/src/repo/operations/zip_changes.rs
+++ b/friendshipper/src-tauri/src/repo/operations/zip_changes.rs
@@ -1,0 +1,500 @@
+use std::collections::HashSet;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::anyhow;
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tracing::{info, instrument, warn};
+use zip::write::FileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+use crate::engine::EngineProvider;
+use crate::state::AppState;
+use ethos_core::types::errors::CoreError;
+use ethos_core::types::repo::FileState;
+
+use super::sanitize_repo_path;
+
+const MANIFEST_NAME: &str = ".friendshipper-zip-manifest.json";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipManifestEntry {
+    pub path: String,
+    #[serde(default)]
+    pub display_name: String,
+    pub state: FileState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipManifest {
+    pub version: u32,
+    pub created_by: String,
+    pub created_at: String,
+    pub entries: Vec<ZipManifestEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipLocalChangesRequest {
+    pub files: Vec<String>,
+    pub destination: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipLocalChangesResponse {
+    pub destination: String,
+    pub file_count: usize,
+}
+
+/// Resolves an absolute path provided by the frontend (file dialog output) to a canonical
+/// `PathBuf`. We don't restrict location since this is a destination path the user chose,
+/// but we do reject empty input.
+fn resolve_absolute_destination(input: &str) -> Result<PathBuf, CoreError> {
+    if input.trim().is_empty() {
+        return Err(CoreError::Input(anyhow!("Destination path is empty")));
+    }
+    Ok(PathBuf::from(input))
+}
+
+/// Builds an in-tree absolute path from the repo root and a sanitized repo-relative path.
+fn join_repo_path(repo_root: &Path, rel: &str) -> PathBuf {
+    let mut p = repo_root.to_path_buf();
+    for seg in rel.split('/') {
+        p.push(seg);
+    }
+    p
+}
+
+#[instrument(skip(state, req))]
+pub async fn zip_local_changes_handler<T>(
+    State(state): State<AppState<T>>,
+    Json(req): Json<ZipLocalChangesRequest>,
+) -> Result<Json<ZipLocalChangesResponse>, CoreError>
+where
+    T: EngineProvider,
+{
+    if req.files.is_empty() {
+        return Err(CoreError::Input(anyhow!("No files selected")));
+    }
+
+    let repo_path = state.app_config.read().repo_path.clone();
+    let repo_root = PathBuf::from(&repo_path);
+    if !repo_root.is_dir() {
+        return Err(CoreError::Internal(anyhow!(
+            "Repo path does not exist: {}",
+            repo_path
+        )));
+    }
+
+    let dest_path = resolve_absolute_destination(&req.destination)?;
+    if let Some(parent) = dest_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| {
+                CoreError::Internal(anyhow!("Failed to create destination directory: {}", e))
+            })?;
+        }
+    }
+
+    // Pull current repo state so we can record file states for each entry.
+    let (modified_files, untracked_files) = {
+        let status = state.repo_status.read();
+        (
+            status.modified_files.clone(),
+            status.untracked_files.clone(),
+        )
+    };
+
+    let user_display_name = state.app_config.read().user_display_name.clone();
+
+    let dest_file = File::create(&dest_path)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to create zip: {}", e)))?;
+    let mut writer = ZipWriter::new(BufWriter::new(dest_file));
+    let options: FileOptions = FileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+
+    let mut manifest_entries: Vec<ZipManifestEntry> = Vec::with_capacity(req.files.len());
+
+    for raw_path in &req.files {
+        let rel = sanitize_repo_path(raw_path)?;
+        if rel.is_empty() {
+            return Err(CoreError::Input(anyhow!("Empty file path provided")));
+        }
+
+        let (state_value, display_name) = match modified_files.get(&rel) {
+            Some(f) => (f.state.clone(), f.display_name.clone()),
+            None => match untracked_files.get(&rel) {
+                Some(f) => (f.state.clone(), f.display_name.clone()),
+                None => (FileState::Unknown, String::new()),
+            },
+        };
+
+        manifest_entries.push(ZipManifestEntry {
+            path: rel.clone(),
+            display_name,
+            state: state_value.clone(),
+        });
+
+        // Deleted files have no working-tree contents; the manifest records
+        // the deletion and the importer removes the file on extract.
+        if matches!(state_value, FileState::Deleted) {
+            continue;
+        }
+
+        let abs_path = join_repo_path(&repo_root, &rel);
+        if !abs_path.exists() {
+            warn!(
+                "Skipping file content for {}: not present in working tree",
+                rel
+            );
+            continue;
+        }
+        if !abs_path.is_file() {
+            warn!("Skipping {}: not a regular file", rel);
+            continue;
+        }
+
+        writer
+            .start_file(&rel, options)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to start zip entry: {}", e)))?;
+        let src = File::open(&abs_path)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to open {}: {}", rel, e)))?;
+        let mut src = BufReader::with_capacity(64 * 1024, src);
+        std::io::copy(&mut src, &mut writer)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to write {} to zip: {}", rel, e)))?;
+    }
+
+    let manifest = ZipManifest {
+        version: 1,
+        created_by: user_display_name,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        entries: manifest_entries,
+    };
+    let manifest_json = serde_json::to_vec_pretty(&manifest)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to serialize manifest: {}", e)))?;
+    writer
+        .start_file(MANIFEST_NAME, options)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to start manifest entry: {}", e)))?;
+    writer
+        .write_all(&manifest_json)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to write manifest: {}", e)))?;
+
+    writer
+        .finish()
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to finish zip: {}", e)))?;
+
+    info!("Wrote {} files to {}", req.files.len(), dest_path.display());
+
+    Ok(Json(ZipLocalChangesResponse {
+        destination: dest_path.to_string_lossy().to_string(),
+        file_count: req.files.len(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportZipQuery {
+    pub source: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipPreviewEntry {
+    pub path: String,
+    pub display_name: String,
+    pub state: FileState,
+    pub size: u64,
+    /// True if this path is currently in the user's modified or untracked file
+    /// list — extracting will overwrite uncommitted local changes.
+    pub conflicts_with_local: bool,
+    /// True if a file at this path already exists on disk. Combined with
+    /// `conflicts_with_local`, the UI calls out the most severe case.
+    pub exists_on_disk: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipPreviewResponse {
+    pub source: String,
+    pub created_by: Option<String>,
+    pub created_at: Option<String>,
+    pub entries: Vec<ZipPreviewEntry>,
+}
+
+fn read_zip_manifest<R: Read + std::io::Seek>(archive: &mut ZipArchive<R>) -> Option<ZipManifest> {
+    match archive.by_name(MANIFEST_NAME) {
+        Ok(mut entry) => {
+            let mut buf = String::new();
+            if entry.read_to_string(&mut buf).is_err() {
+                return None;
+            }
+            serde_json::from_str(&buf).ok()
+        }
+        Err(_) => None,
+    }
+}
+
+#[instrument(skip(state, req))]
+pub async fn preview_import_zip_handler<T>(
+    State(state): State<AppState<T>>,
+    axum::extract::Query(req): axum::extract::Query<ImportZipQuery>,
+) -> Result<Json<ZipPreviewResponse>, CoreError>
+where
+    T: EngineProvider,
+{
+    let source = PathBuf::from(&req.source);
+    if !source.is_file() {
+        return Err(CoreError::Input(anyhow!(
+            "Zip file does not exist: {}",
+            req.source
+        )));
+    }
+
+    let file = File::open(&source)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to open zip: {}", e)))?;
+    let mut archive = ZipArchive::new(BufReader::new(file))
+        .map_err(|e| CoreError::Input(anyhow!("Not a valid zip file: {}", e)))?;
+
+    let manifest = read_zip_manifest(&mut archive);
+
+    let repo_path = state.app_config.read().repo_path.clone();
+    let repo_root = PathBuf::from(&repo_path);
+
+    let (modified_files, untracked_files) = {
+        let status = state.repo_status.read();
+        (
+            status.modified_files.clone(),
+            status.untracked_files.clone(),
+        )
+    };
+    let in_local =
+        |rel: &str| -> bool { modified_files.contains(rel) || untracked_files.contains(rel) };
+
+    // If a manifest is present, treat it as authoritative for the entry list
+    // (so deletions show up in the preview even though they are not zip entries).
+    let mut entries: Vec<ZipPreviewEntry> = Vec::new();
+    if let Some(m) = &manifest {
+        for entry in &m.entries {
+            let rel = sanitize_repo_path(&entry.path)?;
+            if rel.is_empty() {
+                continue;
+            }
+            let abs = join_repo_path(&repo_root, &rel);
+            let size = if matches!(entry.state, FileState::Deleted) {
+                0
+            } else {
+                archive.by_name(&rel).map(|e| e.size()).unwrap_or(0)
+            };
+            entries.push(ZipPreviewEntry {
+                path: rel.clone(),
+                display_name: entry.display_name.clone(),
+                state: entry.state.clone(),
+                size,
+                conflicts_with_local: in_local(&rel),
+                exists_on_disk: abs.exists(),
+            });
+        }
+    } else {
+        // Fall back to the raw zip listing.
+        for i in 0..archive.len() {
+            let entry = archive
+                .by_index(i)
+                .map_err(|e| CoreError::Internal(anyhow!("Failed to read zip entry: {}", e)))?;
+            if entry.is_dir() {
+                continue;
+            }
+            let name = entry.name().to_string();
+            if name == MANIFEST_NAME {
+                continue;
+            }
+            let rel = sanitize_repo_path(&name)?;
+            if rel.is_empty() {
+                continue;
+            }
+            let abs = join_repo_path(&repo_root, &rel);
+            entries.push(ZipPreviewEntry {
+                path: rel.clone(),
+                display_name: String::new(),
+                state: FileState::Unknown,
+                size: entry.size(),
+                conflicts_with_local: in_local(&rel),
+                exists_on_disk: abs.exists(),
+            });
+        }
+    }
+
+    Ok(Json(ZipPreviewResponse {
+        source: req.source.clone(),
+        created_by: manifest.as_ref().map(|m| m.created_by.clone()),
+        created_at: manifest.as_ref().map(|m| m.created_at.clone()),
+        entries,
+    }))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportZippedChangesRequest {
+    pub source: String,
+    /// Optional repo-relative paths to extract. When `None` or empty, every entry in the
+    /// zip is extracted. When set, only entries whose path is in the list are written
+    /// (and only deletions in the list are applied).
+    #[serde(default)]
+    pub files: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportZippedChangesResponse {
+    pub extracted: usize,
+    pub deleted: usize,
+}
+
+#[instrument(skip(state, req))]
+pub async fn import_zipped_changes_handler<T>(
+    State(state): State<AppState<T>>,
+    Json(req): Json<ImportZippedChangesRequest>,
+) -> Result<Json<ImportZippedChangesResponse>, CoreError>
+where
+    T: EngineProvider,
+{
+    let source = PathBuf::from(&req.source);
+    if !source.is_file() {
+        return Err(CoreError::Input(anyhow!(
+            "Zip file does not exist: {}",
+            req.source
+        )));
+    }
+
+    let repo_path = state.app_config.read().repo_path.clone();
+    let repo_root = PathBuf::from(&repo_path);
+    if !repo_root.is_dir() {
+        return Err(CoreError::Internal(anyhow!(
+            "Repo path does not exist: {}",
+            repo_path
+        )));
+    }
+
+    let file = File::open(&source)
+        .map_err(|e| CoreError::Internal(anyhow!("Failed to open zip: {}", e)))?;
+    let mut archive = ZipArchive::new(BufReader::new(file))
+        .map_err(|e| CoreError::Input(anyhow!("Not a valid zip file: {}", e)))?;
+
+    let manifest = read_zip_manifest(&mut archive);
+
+    // Build the optional allow-list of repo-relative paths the caller wants to import.
+    // Sanitize each so the filter matches the same normalized paths we extract under.
+    let filter: Option<HashSet<String>> = match &req.files {
+        Some(list) if !list.is_empty() => {
+            let mut set = HashSet::with_capacity(list.len());
+            for raw in list {
+                let rel = sanitize_repo_path(raw)?;
+                if !rel.is_empty() {
+                    set.insert(rel);
+                }
+            }
+            Some(set)
+        }
+        _ => None,
+    };
+    let is_allowed = |rel: &str| -> bool {
+        match &filter {
+            Some(set) => set.contains(rel),
+            None => true,
+        }
+    };
+
+    // When a manifest is present it is authoritative for what the import is allowed
+    // to touch — the preview is built from the manifest, so a zip that contains
+    // extra entries beyond what the manifest advertises must NOT silently sneak
+    // them onto disk. Build a set of manifest-listed (non-deleted) repo paths;
+    // extraction skips anything outside it.
+    let manifest_extract_allow: Option<HashSet<String>> = manifest.as_ref().map(|m| {
+        m.entries
+            .iter()
+            .filter(|e| !matches!(e.state, FileState::Deleted))
+            .filter_map(|e| sanitize_repo_path(&e.path).ok())
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
+
+    let mut extracted = 0usize;
+    let mut deleted = 0usize;
+
+    // First, apply any deletions called out in the manifest. We rely on the
+    // sanitizer to prevent traversal outside the repo.
+    if let Some(m) = &manifest {
+        for entry in &m.entries {
+            if matches!(entry.state, FileState::Deleted) {
+                let rel = sanitize_repo_path(&entry.path)?;
+                if rel.is_empty() || !is_allowed(&rel) {
+                    continue;
+                }
+                let abs = join_repo_path(&repo_root, &rel);
+                if abs.is_file() {
+                    fs::remove_file(&abs).map_err(|e| {
+                        CoreError::Internal(anyhow!("Failed to remove {}: {}", rel, e))
+                    })?;
+                    deleted += 1;
+                }
+            }
+        }
+    }
+
+    // Then extract every regular-file entry, skipping the manifest itself and any
+    // entries not advertised by the manifest (when present).
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to read zip entry: {}", e)))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let name = entry.name().to_string();
+        if name == MANIFEST_NAME {
+            continue;
+        }
+        let rel = sanitize_repo_path(&name)?;
+        if rel.is_empty() || !is_allowed(&rel) {
+            continue;
+        }
+        if let Some(allow) = &manifest_extract_allow {
+            if !allow.contains(&rel) {
+                warn!("Skipping zip entry {}: not advertised by manifest", rel);
+                continue;
+            }
+        }
+
+        let abs = join_repo_path(&repo_root, &rel);
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                CoreError::Internal(anyhow!(
+                    "Failed to create directory {}: {}",
+                    parent.display(),
+                    e
+                ))
+            })?;
+        }
+
+        let out = File::create(&abs)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to create {}: {}", rel, e)))?;
+        let mut out = BufWriter::new(out);
+        std::io::copy(&mut entry, &mut out)
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to extract {}: {}", rel, e)))?;
+        out.flush()
+            .map_err(|e| CoreError::Internal(anyhow!("Failed to flush {}: {}", rel, e)))?;
+        extracted += 1;
+    }
+
+    info!(
+        "Imported zip from {}: extracted {}, deleted {}",
+        req.source, extracted, deleted
+    );
+
+    Ok(Json(ImportZippedChangesResponse { extracted, deleted }))
+}

--- a/friendshipper/src-tauri/src/repo/router.rs
+++ b/friendshipper/src-tauri/src/repo/router.rs
@@ -76,4 +76,16 @@ where
         .route("/gh/pulls", get(operations::gh::get_pull_requests))
         .route("/gh/pulls/:id", get(operations::gh::get_pull_request))
         .route("/gh/user", get(operations::gh::get_user))
+        .route(
+            "/zip/local-changes",
+            post(operations::zip_local_changes_handler),
+        )
+        .route(
+            "/zip/import/preview",
+            get(operations::preview_import_zip_handler),
+        )
+        .route(
+            "/zip/import",
+            post(operations::import_zipped_changes_handler::<T>),
+        )
 }

--- a/friendshipper/src/lib/repo.ts
+++ b/friendshipper/src/lib/repo.ts
@@ -6,6 +6,7 @@ import type {
 	FileHistoryResponse,
 	GitHubPullRequest,
 	GitHubStatusResponse,
+	ImportZippedChangesResponse,
 	MergeQueue,
 	ObjectCountResponse,
 	PushRequest,
@@ -14,7 +15,9 @@ import type {
 	RepoStatus,
 	RestoreFileToRevisionRequest,
 	RevertFilesRequest,
-	Snapshot
+	Snapshot,
+	ZipLocalChangesResponse,
+	ZipPreviewResponse
 } from '$lib/types';
 
 export const getCommits = async (
@@ -204,3 +207,16 @@ export const getCommitInfo = async (sha: string): Promise<CommitInfo> =>
 
 export const restoreFileToRevision = async (req: RestoreFileToRevisionRequest): Promise<void> =>
 	invoke('restore_file_to_revision', { req });
+
+export const zipLocalChanges = async (
+	files: string[],
+	destination: string
+): Promise<ZipLocalChangesResponse> => invoke('zip_local_changes', { files, destination });
+
+export const previewImportZip = async (source: string): Promise<ZipPreviewResponse> =>
+	invoke('preview_import_zip', { source });
+
+export const importZippedChanges = async (
+	source: string,
+	files: string[] | null = null
+): Promise<ImportZippedChangesResponse> => invoke('import_zipped_changes', { source, files });

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -559,3 +559,29 @@ export interface CommitInfo {
 	subject: string;
 	message: string;
 }
+
+export interface ZipLocalChangesResponse {
+	destination: string;
+	fileCount: number;
+}
+
+export interface ZipPreviewEntry {
+	path: string;
+	displayName: string;
+	state: 'Unknown' | 'Added' | 'Modified' | 'Deleted' | 'Unmerged';
+	size: number;
+	conflictsWithLocal: boolean;
+	existsOnDisk: boolean;
+}
+
+export interface ZipPreviewResponse {
+	source: string;
+	createdBy: string | null;
+	createdAt: string | null;
+	entries: ZipPreviewEntry[];
+}
+
+export interface ImportZippedChangesResponse {
+	extracted: number;
+	deleted: number;
+}

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -4,6 +4,7 @@
 		Button,
 		ButtonGroup,
 		Card,
+		Checkbox,
 		Dropdown,
 		DropdownItem,
 		Input,
@@ -11,6 +12,7 @@
 		Modal,
 		Select,
 		Spinner,
+		Toggle,
 		TabItem,
 		Table,
 		TableBody,
@@ -36,6 +38,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { emit } from '@tauri-apps/api/event';
 	import { open } from '@tauri-apps/plugin-shell';
+	import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog';
 	import { sendNotification } from '@tauri-apps/plugin-notification';
 	import {
 		type ChangeSet,
@@ -54,7 +57,9 @@
 		type PushRequest,
 		type RepoStatus,
 		type RevertFilesRequest,
-		type Snapshot
+		type Snapshot,
+		type ZipPreviewEntry,
+		type ZipPreviewResponse
 	} from '$lib/types';
 	import {
 		acquireLocks,
@@ -65,9 +70,11 @@
 		getCommitFileTextClass,
 		getPullRequests,
 		getRepoStatus,
+		importZippedChanges,
 		listSnapshots,
 		openProject,
 		openSln,
+		previewImportZip,
 		quickSubmit,
 		reinstallGitHooks,
 		restoreSnapshot,
@@ -77,7 +84,8 @@
 		showCommitFiles,
 		syncEngineCommitWithUproject,
 		syncLatest,
-		syncUprojectWithEngineCommit
+		syncUprojectWithEngineCommit,
+		zipLocalChanges
 	} from '$lib/repo';
 	import {
 		activeProjectConfig,
@@ -124,6 +132,17 @@
 
 	// quick submit preview
 	let showQuickSubmitPreview = false;
+
+	// zip local changes
+	let showZipPreview = false;
+	let zipping = false;
+
+	// import zipped changes
+	let showImportPreview = false;
+	let importPreview: ZipPreviewResponse | null = null;
+	let importing = false;
+	let importSelective = false;
+	let importSelectedPaths: Set<string> = new Set();
 
 	// progress modal
 	let showProgressModal = false;
@@ -460,6 +479,7 @@
 					lastQuickSubmitScope: tempCommitScope
 				};
 				await updateAppConfig(updatedConfig).catch((e) => {
+					// eslint-disable-next-line no-console
 					console.warn('Failed to persist quick submit preferences:', e);
 				});
 				$appConfig = updatedConfig;
@@ -650,6 +670,169 @@
 		loading = false;
 		showProgressModal = false;
 	};
+
+	const handleZipLocalChanges = async () => {
+		if ($selectedFiles.length === 0) return;
+
+		const defaultName = `friendshipper-changes-${new Date().toISOString().slice(0, 10)}.zip`;
+		const dest = await saveDialog({
+			defaultPath: defaultName,
+			filters: [{ name: 'Zip Archive', extensions: ['zip'] }]
+		});
+
+		if (!dest) return;
+
+		zipping = true;
+		showProgressModal = true;
+		progressModalTitle = 'Zipping local changes';
+
+		try {
+			const result = await zipLocalChanges(
+				$selectedFiles.map((file) => file.path),
+				dest
+			);
+			showZipPreview = false;
+			await emit(
+				'success',
+				`Wrote ${result.fileCount} file${result.fileCount === 1 ? '' : 's'} to ${
+					result.destination
+				}`
+			);
+		} catch (e) {
+			await emit('error', e);
+		}
+
+		showProgressModal = false;
+		zipping = false;
+	};
+
+	const handleStartImport = async () => {
+		const source = await openDialog({
+			multiple: false,
+			directory: false,
+			filters: [{ name: 'Zip Archive', extensions: ['zip'] }]
+		});
+
+		if (!source || Array.isArray(source)) return;
+
+		try {
+			importPreview = await previewImportZip(source);
+			importSelective = false;
+			importSelectedPaths = new Set(importPreview.entries.map((e) => e.path));
+			showImportPreview = true;
+		} catch (e) {
+			await emit('error', e);
+		}
+	};
+
+	const toggleImportEntry = (path: string) => {
+		if (importSelectedPaths.has(path)) {
+			importSelectedPaths.delete(path);
+		} else {
+			importSelectedPaths.add(path);
+		}
+		importSelectedPaths = new Set(importSelectedPaths);
+	};
+
+	const setAllImportEntries = (checked: boolean) => {
+		if (!importPreview) return;
+		importSelectedPaths = checked ? new Set(importPreview.entries.map((e) => e.path)) : new Set();
+	};
+
+	const handleConfirmImport = async () => {
+		if (!importPreview) return;
+
+		const allSelected = importSelectedPaths.size === importPreview.entries.length;
+		const subset = importSelective && !allSelected ? Array.from(importSelectedPaths) : null;
+
+		// Anything we're about to extract that has uncommitted local changes will
+		// be clobbered (overwrites or deletions). Snapshot those paths first so
+		// the user has a way back.
+		const entriesToImport = importPreview.entries.filter(
+			(entry) => subset === null || importSelectedPaths.has(entry.path)
+		);
+		const pathsAtRisk = entriesToImport
+			.filter((entry) => entry.conflictsWithLocal)
+			.map((entry) => entry.path);
+
+		importing = true;
+		showProgressModal = true;
+
+		try {
+			if (pathsAtRisk.length > 0) {
+				progressModalTitle = 'Snapshotting local changes before import';
+				const zipName = importPreview.source.split(/[\\/]/).pop() || importPreview.source;
+				await saveSnapshot(`Auto-snapshot before importing ${zipName}`, pathsAtRisk);
+				await refreshSnapshots();
+			}
+
+			progressModalTitle = 'Importing zipped changes';
+			const result = await importZippedChanges(importPreview.source, subset);
+			showImportPreview = false;
+			importPreview = null;
+			importSelective = false;
+			importSelectedPaths = new Set();
+
+			await refreshFiles(true);
+
+			const parts: string[] = [];
+			if (result.extracted > 0) {
+				parts.push(`extracted ${result.extracted}`);
+			}
+			if (result.deleted > 0) {
+				parts.push(`deleted ${result.deleted}`);
+			}
+			if (pathsAtRisk.length > 0) {
+				parts.push(
+					`snapshotted ${pathsAtRisk.length} local change${pathsAtRisk.length === 1 ? '' : 's'}`
+				);
+			}
+			const summary = parts.length > 0 ? ` (${parts.join(', ')})` : '';
+			await emit('success', `Imported zipped changes${summary}`);
+		} catch (e) {
+			await emit('error', e);
+		}
+
+		showProgressModal = false;
+		importing = false;
+	};
+
+	const getImportEntryTextClass = (entry: ZipPreviewEntry): string => {
+		if (entry.conflictsWithLocal) {
+			return 'text-red-500 dark:text-red-500';
+		}
+		if (entry.state === 'Added') {
+			return 'text-lime-500 dark:text-lime-500';
+		}
+		if (entry.state === 'Deleted') {
+			return 'text-yellow-300 dark:text-gray-300';
+		}
+		if (entry.state === 'Modified') {
+			return 'text-yellow-300 dark:text-yellow-300';
+		}
+		return 'text-white';
+	};
+
+	$: importConflictCount = importPreview?.entries.filter((e) => e.conflictsWithLocal).length ?? 0;
+	$: importSelectedConflictCount =
+		importPreview?.entries.filter((e) => e.conflictsWithLocal && importSelectedPaths.has(e.path))
+			.length ?? 0;
+	$: importTotal = importPreview?.entries.length ?? 0;
+	// Surface the riskiest entries first: conflicts with local changes, then plain
+	// disk overwrites, then everything else. Array#sort with a stable key keeps
+	// each tier in the manifest's original order.
+	$: importSortedEntries = importPreview
+		? [...importPreview.entries].sort((a, b) => {
+				const rank = (e: ZipPreviewEntry) => {
+					if (e.conflictsWithLocal) return 0;
+					if (e.existsOnDisk && e.state !== 'Deleted') return 1;
+					return 2;
+				};
+				return rank(a) - rank(b);
+		  })
+		: [];
+	$: importAllSelected = importTotal > 0 && importSelectedPaths.size === importTotal;
+	$: importSomeSelected = importSelectedPaths.size > 0 && importSelectedPaths.size < importTotal;
 
 	const handleOpenPreferences = async () => {
 		promptForPAT = false;
@@ -990,7 +1173,44 @@
 			onLockSelected={handleLockSelected}
 			onRightClick={onModifiedFileRightClick}
 			onShowFileHistory={showFileHistory}
-		/>
+		>
+			<Button
+				slot="actions-dropdown-trigger"
+				size="xs"
+				color="primary"
+				id="modified-files-actions-dropdown"
+				disabled={loading || zipping || importing}
+			>
+				<ChevronDownOutline size="xs" />
+			</Button>
+			<Dropdown
+				slot="actions-dropdown"
+				placement="bottom-end"
+				triggeredBy="#modified-files-actions-dropdown"
+			>
+				<DropdownItem
+					class="text-xs"
+					disabled={$selectedFiles.length === 0 || zipping}
+					on:click={() => {
+						if ($selectedFiles.length === 0) return;
+						showZipPreview = true;
+					}}
+				>
+					Zip Local Changes{$selectedFiles.length > 0 ? ` (${$selectedFiles.length})` : ''}
+				</DropdownItem>
+				<Tooltip class="text-xs w-[22rem]" placement="left"
+					>Bundle the selected files into a zip preserving their repo paths so a teammate can drop
+					them onto their working tree.</Tooltip
+				>
+				<DropdownItem class="text-xs" disabled={importing} on:click={handleStartImport}
+					>Import Zipped Changes</DropdownItem
+				>
+				<Tooltip class="text-xs w-[22rem]" placement="left"
+					>Pick a zip created by Zip Local Changes and extract it on top of your repo. You'll see a
+					preview before anything is written.</Tooltip
+				>
+			</Dropdown>
+		</ModifiedFilesCard>
 	</div>
 	<div class="flex flex-col h-full gap-2 w-full max-w-[32rem]">
 		<Card
@@ -1372,6 +1592,196 @@
 					showQuickSubmitPreview = false;
 					await handleQuickSubmit();
 				}}>Confirm Submit</Button
+			>
+		</div>
+	</div>
+</Modal>
+
+<Modal
+	open={showZipPreview}
+	dismissable={true}
+	on:close={() => {
+		showZipPreview = false;
+	}}
+	class="bg-secondary-700 dark:bg-space-900"
+	backdropClass="fixed mt-8 inset-0 z-40 bg-gray-900 bg-opacity-50 dark:bg-opacity-80"
+	dialogClass="fixed mt-8 top-0 start-0 end-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 pb-12 flex"
+	size="md"
+>
+	<div class="flex flex-col gap-3">
+		<h3 class="text-lg font-semibold text-white">Zip Local Changes Preview</h3>
+		<p class="text-sm text-gray-400">
+			{$selectedFiles.length} file{$selectedFiles.length === 1 ? '' : 's'} will be bundled. Hover an
+			OFPA file to see its full repo path.
+		</p>
+		<div
+			class="bg-secondary-800 dark:bg-space-950 p-2 max-h-64 overflow-y-auto rounded text-nowrap"
+		>
+			{#each $selectedFiles as file}
+				<div class="flex gap-2 items-center" role="listitem">
+					{#if file.state === ModifiedFileState.Added}
+						<PlusOutline class="w-4 h-4 text-lime-500 shrink-0" />
+					{:else if file.state === ModifiedFileState.Modified}
+						<PenSolid class="w-4 h-4 text-yellow-300 shrink-0" />
+					{:else if file.state === ModifiedFileState.Deleted}
+						<CloseCircleSolid class="w-4 h-4 text-red-700 shrink-0" />
+					{:else if file.state === ModifiedFileState.Unmerged}
+						<FileCopySolid class="w-4 h-4 text-red-700 shrink-0" />
+					{/if}
+					<span class="truncate {getFileTextClass(file)}" title={file.path}
+						>{getFileDisplayString(file)}</span
+					>
+				</div>
+			{/each}
+		</div>
+		<div class="flex justify-end gap-2">
+			<Button
+				size="sm"
+				color="alternative"
+				disabled={zipping}
+				on:click={() => {
+					showZipPreview = false;
+				}}>Cancel</Button
+			>
+			<Button
+				size="sm"
+				color="primary"
+				disabled={zipping || $selectedFiles.length === 0}
+				on:click={handleZipLocalChanges}>Choose destination & zip</Button
+			>
+		</div>
+	</div>
+</Modal>
+
+<Modal
+	open={showImportPreview}
+	dismissable={true}
+	on:close={() => {
+		showImportPreview = false;
+		importPreview = null;
+	}}
+	class="bg-secondary-700 dark:bg-space-900"
+	backdropClass="fixed mt-8 inset-0 z-40 bg-gray-900 bg-opacity-50 dark:bg-opacity-80"
+	dialogClass="fixed mt-8 top-0 start-0 end-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 pb-12 flex"
+	size="lg"
+>
+	<div class="flex flex-col gap-3">
+		<h3 class="text-lg font-semibold text-white">Import Zipped Changes</h3>
+		{#if importPreview}
+			<p class="text-xs text-gray-400 break-all">Source: {importPreview.source}</p>
+			{#if importPreview.createdBy || importPreview.createdAt}
+				<p class="text-xs text-gray-400">
+					Created
+					{#if importPreview.createdBy}by <span class="text-primary-400"
+							>{importPreview.createdBy}</span
+						>{/if}
+					{#if importPreview.createdAt}
+						on {new Date(importPreview.createdAt).toLocaleString()}
+					{/if}
+				</p>
+			{/if}
+			<p class="text-sm text-gray-300">
+				{importSelective ? importSelectedPaths.size : importTotal} of {importTotal} file{importTotal ===
+				1
+					? ''
+					: 's'} will be written to your repo.
+				{#if importSelective ? importSelectedConflictCount > 0 : importConflictCount > 0}
+					<span class="text-red-400 font-semibold"
+						>{importSelective ? importSelectedConflictCount : importConflictCount} will overwrite uncommitted
+						local change{(importSelective ? importSelectedConflictCount : importConflictCount) === 1
+							? ''
+							: 's'}.</span
+					>
+				{/if}
+			</p>
+			<div class="flex flex-row items-center justify-between gap-2 px-1">
+				<Toggle bind:checked={importSelective} class="text-sm text-gray-300"
+					>Selectively choose files</Toggle
+				>
+				{#if importSelective}
+					<div class="flex items-center gap-2 text-sm text-gray-300">
+						<Checkbox
+							class="!p-1.5"
+							checked={importAllSelected}
+							indeterminate={importSomeSelected}
+							on:change={() => {
+								setAllImportEntries(!importAllSelected);
+							}}>{importAllSelected ? 'Deselect all' : 'Select all'}</Checkbox
+						>
+					</div>
+				{/if}
+			</div>
+			<div
+				class="bg-secondary-800 dark:bg-space-950 p-2 max-h-72 overflow-y-auto rounded text-nowrap"
+			>
+				{#each importSortedEntries as entry}
+					{@const checked = importSelectedPaths.has(entry.path)}
+					{@const dimmed = importSelective && !checked}
+					<div class="flex gap-2 items-center" class:opacity-40={dimmed} role="listitem">
+						{#if importSelective}
+							<Checkbox
+								class="!p-1.5 shrink-0"
+								{checked}
+								on:change={() => {
+									toggleImportEntry(entry.path);
+								}}
+							/>
+						{/if}
+						{#if entry.state === 'Added'}
+							<PlusOutline class="w-4 h-4 text-lime-500 shrink-0" />
+						{:else if entry.state === 'Modified'}
+							<PenSolid class="w-4 h-4 text-yellow-300 shrink-0" />
+						{:else if entry.state === 'Deleted'}
+							<CloseCircleSolid class="w-4 h-4 text-red-700 shrink-0" />
+						{:else if entry.state === 'Unmerged'}
+							<FileCopySolid class="w-4 h-4 text-red-700 shrink-0" />
+						{:else}
+							<FileCodeSolid class="w-4 h-4 text-gray-400 shrink-0" />
+						{/if}
+						<span
+							class="truncate {getImportEntryTextClass(entry)}"
+							title={entry.displayName && entry.displayName !== entry.path
+								? `${entry.displayName} — ${entry.path}`
+								: entry.path}
+						>
+							{entry.displayName !== '' ? entry.displayName : entry.path}
+						</span>
+						{#if entry.conflictsWithLocal}
+							<span class="text-xs text-red-400 shrink-0">[overwrites local change]</span>
+						{:else if entry.existsOnDisk && entry.state !== 'Deleted'}
+							<span class="text-xs text-yellow-400 shrink-0">[overwrites file]</span>
+						{/if}
+					</div>
+				{/each}
+			</div>
+			{#if (importSelective ? importSelectedConflictCount : importConflictCount) > 0}
+				<p class="text-xs text-yellow-300">
+					A snapshot of the affected local changes will be saved automatically before the import so
+					you can restore them.
+				</p>
+			{/if}
+		{:else}
+			<Spinner class="w-4 h-4" />
+		{/if}
+		<div class="flex justify-end gap-2">
+			<Button
+				size="sm"
+				color="alternative"
+				disabled={importing}
+				on:click={() => {
+					showImportPreview = false;
+					importPreview = null;
+				}}>Cancel</Button
+			>
+			<Button
+				size="sm"
+				color="primary"
+				disabled={importing ||
+					importPreview === null ||
+					importPreview.entries.length === 0 ||
+					(importSelective && importSelectedPaths.size === 0)}
+				on:click={handleConfirmImport}
+				>Import{importSelective ? ` (${importSelectedPaths.size})` : ''}</Button
 			>
 		</div>
 	</div>


### PR DESCRIPTION
Bundles selected files into a portable zip (with manifest) and imports zips back into the working tree with a preview. Auto-snapshots any local paths the import would clobber. Options can be found in a drop-down next to the snapshot button on the submit page.

fix(core): preserve full snapshot message when it contains "snapshot" 
fix(core): stage deletions via git rm --cached so save_snapshot works
           for selections that include removed files