### PR TITLE
fix(core): use control-byte separators in git log parser

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1236,7 +1236,7 @@ impl Git {
                 "--no-pager",
                 "log",
                 &format!("-{limit}"),
-                "--pretty=format:%H|%B|%an|%aI|END",
+                "--pretty=format:%H%x1f%B%x1f%an%x1f%aI%x1f%x1e",
                 git_ref,
             ],
             Opts::new_without_logs(),

--- a/core/src/operations.rs
+++ b/core/src/operations.rs
@@ -89,9 +89,9 @@ impl LogOp {
 
         let output = self.git_client.log(self.limit, &git_ref).await?;
         let result = output
-            .split("END\n")
+            .split("\x1e\n")
             .filter_map(|line| {
-                let parts = line.split('|').collect::<Vec<_>>();
+                let parts = line.split('\x1f').collect::<Vec<_>>();
 
                 // Ensure we have at least 4 parts
                 if parts.len() < 4 {
@@ -335,10 +335,10 @@ impl BranchCompareOp {
         );
         let output = self.git_client.log(self.limit, &commit_range).await?;
         let result = output
-            .split("END\n")
+            .split("\x1e\n")
             .filter(|line| !line.trim().is_empty())
             .filter_map(|line| {
-                let parts = line.split('|').collect::<Vec<_>>();
+                let parts = line.split('\x1f').collect::<Vec<_>>();
 
                 if parts.len() >= 4 {
                     let full_sha = parts[0];


### PR DESCRIPTION
## Summary
- `git log` parser was failing to read timestamps for any commit whose body contained a `|` character — observed in production logs as warnings like `Failed to parse timestamp 'read_write' from git log: premature end of input`.
- Root cause: the format string `%H|%B|%an|%aI|END` used `|` as a field separator, but `%B` is the raw commit body and routinely contains `|` (code, tables, trailers). Field-split on `|` misaligned `parts[3]`, so the parser fed body fragments to `DateTime::parse_from_rfc3339`.
- Fix: switch field separator to ASCII Unit Separator (`\x1f`) and record separator to Record Separator + newline (`\x1e\n`). Both are effectively impossible in commit text. Trailing `%x1e` on each record continues to act as the sentinel field that absorbs anything after the timestamp on the last record (which has no trailing newline).
- Applied to both consumers of `git_client.log()`: `LogOp::run` (the source of the observed warnings) and `BranchCompareOp` (same latent bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)