### PR TITLE
feat(friendshipper): add deep links for archived utrace files

### DIFF
--- a/friendshipper/src/lib/components/servers/ArchiveModal.svelte
+++ b/friendshipper/src/lib/components/servers/ArchiveModal.svelte
@@ -7,8 +7,9 @@
 		CalendarMonthOutline,
 		LinkOutline
 	} from 'flowbite-svelte-icons';
+	import { onDestroy, onMount } from 'svelte';
 	import { save as saveDialog } from '@tauri-apps/plugin-dialog';
-	import { emit } from '@tauri-apps/api/event';
+	import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
 	import {
 		downloadUtrace,
 		getRecentUtraces,
@@ -186,6 +187,18 @@
 		refreshBusy();
 		void loadRecent();
 	}
+
+	let unlistenDeepLink: UnlistenFn | null = null;
+
+	onMount(async () => {
+		unlistenDeepLink = await listen('trace-deeplink-received', () => {
+			showModal = false;
+		});
+	});
+
+	onDestroy(() => {
+		unlistenDeepLink?.();
+	});
 </script>
 
 <Modal

--- a/friendshipper/src/lib/components/servers/ArchiveModal.svelte
+++ b/friendshipper/src/lib/components/servers/ArchiveModal.svelte
@@ -4,7 +4,8 @@
 		DownloadOutline,
 		PlayOutline,
 		ArrowLeftOutline,
-		CalendarMonthOutline
+		CalendarMonthOutline,
+		LinkOutline
 	} from 'flowbite-svelte-icons';
 	import { save as saveDialog } from '@tauri-apps/plugin-dialog';
 	import { emit } from '@tauri-apps/api/event';
@@ -121,6 +122,18 @@
 		}
 		busyDownload.delete(trace.key);
 		traces = traces;
+	};
+
+	const handleCopyLink = async (trace: TraceEntry) => {
+		const link = `friendshipper://traces/${encodeURIComponent(trace.date)}/${encodeURIComponent(
+			trace.serverName
+		)}/${encodeURIComponent(trace.filename)}`;
+		try {
+			await navigator.clipboard.writeText(link);
+			await emit('success', 'Copied trace link');
+		} catch (e) {
+			await handleError(e);
+		}
 	};
 
 	const handleOpen = async (trace: TraceEntry) => {
@@ -244,6 +257,14 @@
 					>
 						<div class="flex flex-col min-w-0 flex-1">
 							<div class="flex items-center gap-2 min-w-0">
+								<button
+									type="button"
+									class="shrink-0 text-gray-300 hover:text-primary-400 focus:outline-none"
+									title="Copy link to this trace"
+									on:click={() => handleCopyLink(trace)}
+								>
+									<LinkOutline class="w-3.5 h-3.5" />
+								</button>
 								<span class="text-sm text-white truncate" title={trace.filename}>
 									{trace.filename}
 								</span>

--- a/friendshipper/src/lib/components/servers/TraceDeepLinkModal.svelte
+++ b/friendshipper/src/lib/components/servers/TraceDeepLinkModal.svelte
@@ -57,7 +57,7 @@
 <Modal
 	size="sm"
 	color="none"
-	class="bg-secondary-700 dark:bg-space-900"
+	class="trace-deeplink-modal bg-secondary-700 dark:bg-space-900"
 	bodyClass="!border-t-0"
 	backdropClass="fixed mt-8 inset-0 z-40 bg-gray-900 bg-opacity-50 dark:bg-opacity-80"
 	dialogClass="fixed mt-8 top-0 start-0 end-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 pb-12 flex"
@@ -107,3 +107,13 @@
 		</div>
 	{/if}
 </Modal>
+
+<style>
+	/* color="none" leaves the close button without a text color; restore visibility */
+	:global(.trace-deeplink-modal button[aria-label='Close modal']) {
+		color: rgb(156 163 175); /* tailwind gray-400 */
+	}
+	:global(.trace-deeplink-modal button[aria-label='Close modal']:hover) {
+		color: rgb(255 255 255);
+	}
+</style>

--- a/friendshipper/src/lib/components/servers/TraceDeepLinkModal.svelte
+++ b/friendshipper/src/lib/components/servers/TraceDeepLinkModal.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { Button, Modal, Spinner } from 'flowbite-svelte';
+	import { DownloadOutline, PlayOutline } from 'flowbite-svelte-icons';
+	import { save as saveDialog } from '@tauri-apps/plugin-dialog';
+	import { emit } from '@tauri-apps/api/event';
+	import { downloadUtrace, openUtraceInInsights } from '$lib/utrace';
+	import { handleError } from '$lib/utils';
+
+	export let open: boolean;
+	export let trace: {
+		date: string;
+		serverName: string;
+		filename: string;
+		key: string;
+	} | null;
+
+	let downloading = false;
+	let opening = false;
+
+	$: if (!open) {
+		downloading = false;
+		opening = false;
+	}
+
+	const handleDownload = async () => {
+		if (!trace) return;
+		const dest = await saveDialog({
+			defaultPath: trace.filename,
+			filters: [{ name: 'Unreal Insights Trace', extensions: ['utrace'] }]
+		});
+		if (!dest) return;
+
+		downloading = true;
+		try {
+			await downloadUtrace(trace.key, dest);
+			await emit('success', `Saved ${trace.filename} to ${dest}`);
+			open = false;
+		} catch (e) {
+			await handleError(e);
+		}
+		downloading = false;
+	};
+
+	const handleOpen = async () => {
+		if (!trace) return;
+		opening = true;
+		try {
+			await openUtraceInInsights(trace.key);
+			open = false;
+		} catch (e) {
+			await handleError(e);
+		}
+		opening = false;
+	};
+</script>
+
+<Modal
+	size="sm"
+	color="none"
+	class="bg-secondary-700 dark:bg-space-900"
+	bodyClass="!border-t-0"
+	backdropClass="fixed mt-8 inset-0 z-40 bg-gray-900 bg-opacity-50 dark:bg-opacity-80"
+	dialogClass="fixed mt-8 top-0 start-0 end-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 pb-12 flex"
+	bind:open
+	autoclose={false}
+	outsideclose
+>
+	<svelte:fragment slot="header">
+		<h4 class="text-lg font-semibold text-primary-400">Open trace from link</h4>
+	</svelte:fragment>
+
+	{#if trace}
+		<div class="flex flex-col gap-3">
+			<div class="flex flex-col gap-1 min-w-0">
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="text-sm text-white truncate" title={trace.filename}>
+						{trace.filename}
+					</span>
+					<span
+						class="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-secondary-600 dark:bg-space-800 text-gray-300 border border-gray-600"
+						title={trace.serverName}
+					>
+						{trace.serverName}
+					</span>
+				</div>
+				<div class="text-[11px] text-gray-400">{trace.date}</div>
+			</div>
+
+			<div class="flex items-center gap-2">
+				<Button size="xs" outline disabled={downloading || opening} on:click={handleDownload}>
+					{#if downloading}
+						<Spinner size="4" class="mr-1" />
+					{:else}
+						<DownloadOutline class="w-4 h-4 mr-1" />
+					{/if}
+					Download
+				</Button>
+				<Button size="xs" outline disabled={downloading || opening} on:click={handleOpen}>
+					{#if opening}
+						<Spinner size="4" class="mr-1" />
+					{:else}
+						<PlayOutline class="w-4 h-4 mr-1" />
+					{/if}
+					Open with UnrealInsights
+				</Button>
+			</div>
+		</div>
+	{/if}
+</Modal>

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -69,6 +69,7 @@
 	import { cancelDownload, getBuilds, getWorkflows } from '$lib/builds';
 	import { refreshLogin, exitApp } from '$lib/auth';
 	import QuickLaunchModal from '$lib/components/servers/QuickLaunchModal.svelte';
+	import TraceDeepLinkModal from '$lib/components/servers/TraceDeepLinkModal.svelte';
 	import PreferencesModal from '$lib/components/preferences/PreferencesModal.svelte';
 	import {
 		getAllCommits,
@@ -107,6 +108,15 @@
 	// Quick launch stuff
 	let quickLaunching = false;
 	let quickLaunchServerName = '';
+
+	// Trace deep link
+	let traceDeepLinkOpen = false;
+	let traceDeepLink: {
+		date: string;
+		serverName: string;
+		filename: string;
+		key: string;
+	} | null = null;
 
 	// Welcome modal
 	let showWelcomeModal = false;
@@ -1000,6 +1010,20 @@
 			setTimeout(() => {
 				void emit('build-deep-link', { group, commitSha, name });
 			}, 100);
+		} else if (payload.startsWith('traces/')) {
+			const [, rawDate, rawServer, rawFile] = payload.split('/');
+			if (rawDate && rawServer && rawFile) {
+				const date = decodeURIComponent(rawDate);
+				const serverName = decodeURIComponent(rawServer);
+				const filename = decodeURIComponent(rawFile);
+				traceDeepLink = {
+					date,
+					serverName,
+					filename,
+					key: `friendshipper/utrace/${date}/${serverName}/${filename}`
+				};
+				traceDeepLinkOpen = true;
+			}
 		}
 	});
 
@@ -1125,6 +1149,7 @@
 			class="flex bg-secondary-800 dark:bg-space-950 h-full overflow-y-hidden w-full overflow-x-hidden"
 		>
 			<QuickLaunchModal bind:showModal={quickLaunching} serverName={quickLaunchServerName} />
+			<TraceDeepLinkModal bind:open={traceDeepLinkOpen} trace={traceDeepLink} />
 			<Sidebar
 				asideClass="w-56 shadow-md sticky top-0 h-full"
 				activeClass="flex items-center p-2 text-base font-normal text-gray-900 bg-secondary-800 dark:bg-space-950 rounded-lg text-primary-400 dark:text-primary-400 hover:bg-secondary-800 dark:hover:bg-space-950"

--- a/friendshipper/src/routes/+layout.svelte
+++ b/friendshipper/src/routes/+layout.svelte
@@ -1022,6 +1022,7 @@
 					filename,
 					key: `friendshipper/utrace/${date}/${serverName}/${filename}`
 				};
+				void emit('trace-deeplink-received');
 				traceDeepLinkOpen = true;
 			}
 		}


### PR DESCRIPTION
Adds a copy-link button to each row in the Trace Archive and a new modal that handles friendshipper://traces/{date}/{server}/{filename} links by offering Download or Open with UnrealInsights, reusing the existing trace actions.
<img width="978" height="579" alt="image" src="https://github.com/user-attachments/assets/3d1e61ac-d79d-493d-ad3e-570e3b980646" />
