### PR TITLE
fix(friendshipper): stop background fetch from triggering interactive git auth

### DIFF
--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -106,6 +106,10 @@ pub struct Opts<'a> {
     pub return_complete_error: bool,
     pub lfs_mode: LfsMode,
     pub skip_notify_frontend: bool,
+    // When set, the git command runs with interactive credential prompts
+    // disabled. Use for background/non-user-initiated operations so a stale
+    // credential fails quietly instead of spawning a login window.
+    pub skip_interactive_auth: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -123,6 +127,7 @@ impl Default for Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 }
@@ -135,6 +140,7 @@ impl Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -145,6 +151,7 @@ impl Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -155,6 +162,7 @@ impl Opts<'_> {
             return_complete_error: true,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -170,6 +178,11 @@ impl Opts<'_> {
 
     pub fn with_skip_notify_frontend(mut self) -> Self {
         self.skip_notify_frontend = true;
+        self
+    }
+
+    pub fn with_skip_interactive_auth(mut self) -> Self {
+        self.skip_interactive_auth = true;
         self
     }
 }
@@ -1499,8 +1512,13 @@ impl Git {
     }
 
     pub async fn run_maintenance(&self) -> anyhow::Result<()> {
-        self.run(&["maintenance", "run", "--auto"], Opts::default())
-            .await
+        // Runs on the background maintenance loop and may prefetch over the
+        // network, so it must not trigger an interactive credential prompt.
+        self.run(
+            &["maintenance", "run", "--auto"],
+            Opts::default().with_skip_interactive_auth(),
+        )
+        .await
     }
 
     pub async fn run_gc(&self) -> anyhow::Result<()> {
@@ -1609,6 +1627,7 @@ impl Git {
                     return_complete_error: true,
                     lfs_mode: LfsMode::Stubs,
                     skip_notify_frontend: false,
+                    skip_interactive_auth: false,
                 },
             )
             .await?;
@@ -1809,6 +1828,16 @@ impl Git {
 
         // disable clone protection
         cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
+
+        // For background/non-user-initiated commands (e.g. the maintenance fetch
+        // loop), never allow an interactive credential prompt. If the cached
+        // credential is stale, the command fails quietly and the next
+        // user-initiated operation handles re-authentication, instead of a
+        // background loop spawning a GCM login window every few seconds.
+        if opts.skip_interactive_auth {
+            cmd.env("GIT_TERMINAL_PROMPT", "false");
+            cmd.env("GCM_INTERACTIVE", "never");
+        }
 
         if opts.lfs_mode == LfsMode::Stubs {
             cmd.env("GIT_LFS_SKIP_SMUDGE", "1");

--- a/core/src/clients/git_maintenance_runner.rs
+++ b/core/src/clients/git_maintenance_runner.rs
@@ -57,7 +57,9 @@ impl GitMaintenanceRunner {
                     match git
                         .fetch(
                             ShouldPrune::Yes,
-                            Opts::default().with_skip_notify_frontend(),
+                            Opts::default()
+                                .with_skip_notify_frontend()
+                                .with_skip_interactive_auth(),
                         )
                         .await
                     {

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -382,7 +382,7 @@ impl Server {
         if !repo_path.is_empty() {
             let maintenance_runner =
                 GitMaintenanceRunner::new(repo_path, pause_background_tasks.clone(), tx)
-                    .with_fetch_interval(Duration::from_secs(5));
+                    .with_fetch_interval(Duration::from_secs(30));
             tokio::spawn(async move {
                 match maintenance_runner.run().await {
                     Ok(_) => {}


### PR DESCRIPTION
## Problem

`GitMaintenanceRunner` runs `git fetch --prune` on a short interval (5s) while the app is open. Each fetch shells out to `git`, which invokes the configured credential helper. When the stored credential is stale, the **background** fetch was free to launch an interactive credential prompt, and concurrent git processes could each spawn their own helper (the `git-credential-manager` "death spiral" the code already guards against). The result is repeated auth pop-ups unrelated to any user action.

## Fix

- Add a `skip_interactive_auth` option to `Opts`. When set, the git command runs with `GIT_TERMINAL_PROMPT=false` and `GCM_INTERACTIVE=never`, so it can never launch an interactive prompt.
- Apply it to the background fetch loop and to `run_maintenance`. A stale credential now fails quietly (and is logged via the existing `warn!`); re-authentication happens on the next user-initiated operation instead of from a background timer.
- Raise the background fetch interval from 5s to 30s to reduce process churn.

No change to which credential helper is used or to auth requirements. User-initiated pull/push still prompt as before.

## Testing

- `cargo check` clean for `ethos-core` and `friendshipper`.
- Pre-commit hook passes: `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all --check`.

Suggested manual check: with a stale `github.com` credential, confirm an idle app no longer launches a login dialog (background fetch fails quietly and logs a warn), while a user-initiated pull/push still prompts and restores the credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
