### PR TITLE
fix(git): serialize subprocesses, seed PAT into git credentials, self-heal auth

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -84,7 +84,13 @@ obws = "0.11.5"
 futures = "0.3.29"
 toml = "0.8.8"
 async-trait = "0.1"
-windows = { version = "0.56.0", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows = { version = "0.56.0", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
 walkdir = "2.5.0"
 octocrab = "0.39.0"
 bytes = "1.7.2"

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -215,16 +215,28 @@ pub fn parse_bool_string(bool_str: &str) -> anyhow::Result<bool> {
     bail!("Unable to parse string")
 }
 
-/// Wall-clock backstop for a single `git` subprocess. Because every git
-/// process now holds [`GIT_PROCESS_LOCK`] for its whole lifetime, a hung
-/// process — a stuck credential prompt, or a dead connection that never makes
-/// progress — would otherwise hold the lock forever and wedge *every* git
-/// operation in the app. The runner kills such a process so the lock is
-/// released and callers get an error. Set generously so it never trips a
-/// legitimately long op (large fetch, gc/repack). NOTE: a fresh full clone of
-/// a very large repo over a slow link can legitimately exceed this — bump it
-/// or special-case `clone` if that ever bites.
-const GIT_PROCESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+/// Idle (no-progress) backstop for a single `git` subprocess. Because every git
+/// process now holds [`GIT_PROCESS_LOCK`] for its whole lifetime, a hung process
+/// — a stuck credential prompt, or a dead connection that never makes progress —
+/// would otherwise hold the lock forever and wedge *every* git operation in the
+/// app. The runner kills such a process so the lock is released and callers get
+/// an error.
+///
+/// This is deliberately an *idle* timeout, not a wall-clock one: a hung process
+/// is distinguished from a slow-but-healthy one (a large clone / fetch / LFS
+/// pull streaming progress over a slow link) by the *absence of output*, not by
+/// total elapsed time. We reset the clock on every line the child writes, so a
+/// command that keeps making progress is never killed no matter how long it
+/// runs, while one that goes completely silent for this long is treated as hung.
+/// Generous on purpose — only true silence should trip it; it can be lowered now
+/// that progressing ops are safe.
+const GIT_PROCESS_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// How often the idle watchdog wakes to compare now against the child's last
+/// output. Bounds how long past [`GIT_PROCESS_IDLE_TIMEOUT`] a hung process can
+/// linger before it's killed; small relative to the timeout, large enough to be
+/// negligible overhead.
+const GIT_PROCESS_IDLE_CHECK: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Acquire the process-wide git serialization guard. Hold the returned guard
 /// for the full lifetime of a `git` subprocess (spawn through wait). See
@@ -2039,11 +2051,20 @@ impl Git {
         let out_lines: Arc<RwLock<Vec<String>>> = Arc::new(RwLock::new(vec![]));
         let err_lines: Arc<RwLock<Vec<String>>> = Arc::new(RwLock::new(vec![]));
 
+        // Tracks the last time the child produced any output, so the idle
+        // watchdog below can tell a hung process from a slow-but-progressing
+        // one. Both reader tasks bump it on every line.
+        let last_activity: Arc<RwLock<std::time::Instant>> =
+            Arc::new(RwLock::new(std::time::Instant::now()));
+
         let out_lines_thread = out_lines.clone();
+        let out_activity = last_activity.clone();
         let is_collecting_out_lines = output.is_some();
         let should_log_stdout = opts.should_log_stdout;
         let out_handle = tokio::spawn(async move {
             while let Some(line) = out_reader.next_line().await.unwrap() {
+                *out_activity.write() = std::time::Instant::now();
+
                 // Shorten any line starting with "Updating files". Git currently sends us a huge
                 // wall of text with all the individual percentage updates, instead of one line
                 // per update.
@@ -2063,28 +2084,37 @@ impl Git {
         });
 
         let err_lines_thread = err_lines.clone();
+        let err_activity = last_activity.clone();
         let err_handle = tokio::spawn(async move {
             while let Some(line) = err_reader.next_line().await.unwrap() {
+                *err_activity.write() = std::time::Instant::now();
                 err_lines_thread.write().push(line.clone());
                 info!("{}", line);
             }
         });
 
-        let status = match tokio::time::timeout(GIT_PROCESS_TIMEOUT, git_proc.wait()).await {
-            Ok(wait_result) => wait_result?,
-            Err(_elapsed) => {
-                // Exceeded the generous ceiling — almost certainly hung (a stuck
-                // credential prompt, or a dead connection making no progress).
-                // Kill it so it can't hold GIT_PROCESS_LOCK forever and wedge
-                // every other git operation in the app.
-                warn!(
-                    "git command exceeded {:?}; killing hung process: {}",
-                    GIT_PROCESS_TIMEOUT, git_cmd_str
-                );
-                let _ = git_proc.kill().await;
-                let _ = out_handle.await;
-                let _ = err_handle.await;
-                bail!("Git command timed out. Check the log for details.");
+        // Idle watchdog: wake periodically and kill the child only if it has
+        // produced no output for GIT_PROCESS_IDLE_TIMEOUT. A command that keeps
+        // streaming progress (a large clone/fetch/LFS pull) resets the clock on
+        // every line and is never killed for simply taking a long time; only a
+        // truly stalled process (stuck prompt, dead connection) trips it.
+        let status = loop {
+            match tokio::time::timeout(GIT_PROCESS_IDLE_CHECK, git_proc.wait()).await {
+                Ok(wait_result) => break wait_result?,
+                Err(_elapsed) => {
+                    let idle = last_activity.read().elapsed();
+                    if idle >= GIT_PROCESS_IDLE_TIMEOUT {
+                        warn!(
+                            "git command made no progress for {:?}; killing stalled process: {}",
+                            idle, git_cmd_str
+                        );
+                        let _ = git_proc.kill().await;
+                        let _ = out_handle.await;
+                        let _ = err_handle.await;
+                        bail!("Git command stalled with no progress. Check the log for details.");
+                    }
+                    // Still producing output recently — keep waiting.
+                }
             }
         };
 

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1819,17 +1819,15 @@ impl Git {
     /// `host`, so subsequent network git operations authenticate
     /// non-interactively instead of the helper launching a login window.
     ///
-    /// Two steps, in order:
-    /// 1. **Evict** any existing host-level credential for `host`
-    ///    (`git credential reject` with no username). This is the crucial part:
-    ///    git-remote-https (fetch/pull/push) asks the helper for
-    ///    `https://<host>` with *no* username, and a stale entry sitting there —
-    ///    e.g. an expired GCM OAuth token — shadows whatever we store next, so
-    ///    the seed appears to land in the credential store yet fetches keep
-    ///    failing. Rejecting first mirrors clearing the credential by hand,
-    ///    which is what makes the new credential actually resolve for a
-    ///    bare-host fetch.
-    /// 2. **Seed** the new credential (`git credential approve`).
+    /// First checks, non-interactively, whether the helper already serves this
+    /// exact credential for a bare `https://<host>` request (what fetch/pull/
+    /// push use). If it does, this is a no-op — we don't touch a credential
+    /// store we don't own. Only when the stored value is wrong or missing do we
+    /// replace it: evict the stale host-level entry (`git credential reject`
+    /// with no username), then seed the new one (`git credential approve`). The
+    /// evict is required because a stale entry (e.g. an expired GCM OAuth token)
+    /// otherwise shadows what we store, so a bare-host `git fetch` keeps failing
+    /// even though the seed appears to land.
     ///
     /// The credential is fed over **stdin** — never on the command line — so the
     /// secret never lands in process arguments, our git-output channel, or the
@@ -1857,18 +1855,27 @@ impl Git {
             username
         };
 
-        // Narrate the action + its effect so the logs explain why a stored
-        // credential changed out from under the user. Host + username only —
-        // never the password.
+        // Hold the process lock across the check and any replacement, like
+        // every other spawn site.
+        let _git_lock = acquire_git_process_lock("git credential (check + refresh)").await;
+
+        // If the helper already serves exactly this credential for a bare-host
+        // request, there's nothing to do. Skipping avoids churning a store we
+        // don't own — and the brief window where the reject below has removed
+        // the entry — so we mutate only when the stored value is wrong or
+        // missing.
+        if self.current_credential_password(host).await.as_deref() == Some(password) {
+            debug!("git credential for {host} already current; leaving it untouched");
+            return Ok(());
+        }
+
+        // Narrate the action + effect so the logs explain why a stored
+        // credential changed. Host + username only — never the password.
         info!(
             "Refreshing git credential for {host} from the saved PAT (username: {username}): \
-             evicting any stale host-level entry, then re-seeding the credential helper so \
+             evicting the stale host-level entry, then re-seeding the credential helper so \
              background fetch/pull/push/lfs authenticate without an interactive login."
         );
-
-        // Spawns git processes (and the helper), so hold the process lock for
-        // the whole reject + approve pair like every other spawn site.
-        let _git_lock = acquire_git_process_lock("git credential (reject + approve)").await;
 
         // Step 1 — evict. Best-effort: `reject` is a no-op when nothing is
         // stored, and a hiccup here must not block re-seeding, so its result is
@@ -1894,6 +1901,28 @@ impl Git {
 
         info!("Stored git credential for {host} refreshed (username: {username})");
         Ok(())
+    }
+
+    /// Password the configured credential helper currently serves for a bare
+    /// `https://<host>` request (what git-remote-https uses), or `None` if
+    /// nothing is stored. Runs non-interactively, so the check itself can never
+    /// launch a credential prompt. Used by [`Self::store_credential`] to skip
+    /// replacing a credential that already matches.
+    async fn current_credential_password(&self, host: &str) -> Option<String> {
+        let mut cmd = self.build_credential_command("fill").ok()?;
+        // Never prompt just to read the current value.
+        cmd.env("GIT_TERMINAL_PROMPT", "false");
+        cmd.env("GCM_INTERACTIVE", "never");
+        let input = format!("protocol=https\nhost={host}\n\n");
+        let output = crate::utils::process::run_with_stdin(cmd, input.into_bytes())
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find_map(|l| l.strip_prefix("password=").map(str::to_string))
     }
 
     #[instrument]
@@ -2423,6 +2452,32 @@ mod tests {
         assert!(
             !stdout.contains("ghp_STALEvalue"),
             "stale credential was not evicted before seeding: {stdout}"
+        );
+
+        // Seeding the SAME credential again hits the "already current" fast
+        // path (fill matches → no reject/approve) and must leave it intact.
+        git.store_credential("github.com", "", "ghp_seededtoken")
+            .await
+            .expect("store_credential (idempotent)");
+        let mut child = StdCommand::new("git")
+            .args(["credential", "fill"])
+            .current_dir(&git.repo_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn git credential fill");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"protocol=https\nhost=github.com\n\n")
+            .unwrap();
+        let out = child.wait_with_output().expect("fill output");
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("password=ghp_seededtoken"),
+            "credential not intact after idempotent re-seed: {stdout}"
         );
     }
 

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1712,6 +1712,67 @@ impl Git {
         self.run(&["config", key, value], Opts::default()).await
     }
 
+    /// Seed git's configured credential helper with an HTTPS credential for
+    /// `host`, so subsequent network git operations authenticate
+    /// non-interactively instead of the helper launching a login window.
+    ///
+    /// The credential is fed to `git credential approve` over **stdin** — never
+    /// on the command line — so the secret never lands in process arguments,
+    /// our git-output channel, or the logs. Whatever helper the user has
+    /// configured (e.g. Git Credential Manager) performs the actual storage,
+    /// keyed by host; re-seeding overwrites whatever it had cached, including a
+    /// stale credential the helper erased after a prior 401.
+    ///
+    /// This is how a non-expiring PAT held in the app keyring becomes *git's*
+    /// credential (the in-app PAT otherwise only feeds the GitHub HTTP API,
+    /// never git). `username` should be the GitHub login when known; for a
+    /// classic PAT the value is ignored by GitHub, so an empty string falls
+    /// back to the conventional `x-access-token` rather than leaving git with
+    /// an incomplete credential it would prompt to fill.
+    ///
+    /// Best-effort: if no credential helper is configured, `git credential
+    /// approve` is a no-op and this returns `Ok`.
+    pub async fn store_credential(
+        &self,
+        host: &str,
+        username: &str,
+        password: &str,
+    ) -> anyhow::Result<()> {
+        let username = if username.is_empty() {
+            "x-access-token"
+        } else {
+            username
+        };
+
+        // git's credential protocol: key=value lines terminated by a blank
+        // line. The password line carries the secret; everything below treats
+        // `input` as sensitive (no logging, fed only via stdin).
+        let input =
+            format!("protocol=https\nhost={host}\nusername={username}\npassword={password}\n\n");
+
+        let mut cmd = Command::new("git");
+        cmd.args(["credential", "approve"]);
+        cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
+        if !self.repo_path.as_os_str().is_empty() {
+            cmd.current_dir(&self.repo_path.canonicalize()?);
+        }
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+
+        // Note: host + username only — never the password.
+        info!("Seeding git credential for host {host} (username: {username})");
+
+        // Spawns a git process (and the helper), so hold the process lock like
+        // every other spawn site. `run_with_stdin` does not log stdin.
+        let _git_lock = acquire_git_process_lock().await;
+        let output = crate::utils::process::run_with_stdin(cmd, input.into_bytes()).await?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("git credential approve failed: {}", stderr.trim());
+        }
+        Ok(())
+    }
+
     #[instrument]
     pub async fn configure_untracked_cache(&self) -> anyhow::Result<()> {
         // get current setting for core.untrackedCache
@@ -2128,6 +2189,74 @@ mod tests {
         let (tx, _rx) = mpsc::channel();
         let git = Git::new(path, tx);
         (git, dir)
+    }
+
+    // store_credential must actually make the credential retrievable via git's
+    // own credential plumbing — that's the whole point of seeding the PAT so
+    // network git stops prompting. We point credential.helper at a throwaway
+    // file (never the user's real store), seed a token, then `git credential
+    // fill` and assert the seeded username/password come back. Also covers the
+    // empty-username fallback to `x-access-token`, so git never gets an
+    // incomplete credential it would prompt to complete.
+    #[tokio::test]
+    async fn test_store_credential_is_retrievable_via_fill() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let (git, dir) = setup_repo();
+
+        // Isolate from the developer's real credential helper (e.g. a global
+        // GCM): an empty `credential.helper` value resets the inherited helper
+        // list, so only the throwaway `store` helper added afterward runs for
+        // this repo. Without the reset, git consults the global helper too and
+        // both `approve` (touching the real store!) and `fill` (shadowing our
+        // seeded value with the real one) would leak across the test boundary.
+        let cred_file = dir.path().join("creds");
+        let helper = format!(
+            "store --file={}",
+            cred_file.to_string_lossy().replace('\\', "/")
+        );
+        for args in [
+            &["config", "--local", "credential.helper", ""][..],
+            &["config", "--local", "--add", "credential.helper", &helper][..],
+        ] {
+            let out = StdCommand::new("git")
+                .args(args)
+                .current_dir(&git.repo_path)
+                .output()
+                .expect("set credential.helper");
+            assert!(out.status.success());
+        }
+
+        // Empty username must fall back to x-access-token.
+        git.store_credential("github.com", "", "ghp_seededtoken")
+            .await
+            .expect("store_credential");
+
+        let mut child = StdCommand::new("git")
+            .args(["credential", "fill"])
+            .current_dir(&git.repo_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn git credential fill");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"protocol=https\nhost=github.com\n\n")
+            .unwrap();
+        let out = child.wait_with_output().expect("fill output");
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("password=ghp_seededtoken"),
+            "fill did not return seeded password: {stdout}"
+        );
+        assert!(
+            stdout.contains("username=x-access-token"),
+            "fill did not return fallback username: {stdout}"
+        );
     }
 
     // Regression: startup maintenance expired reflogs with the expiry window

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -248,6 +248,41 @@ const GIT_PROCESS_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// negligible overhead.
 const GIT_PROCESS_IDLE_CHECK: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// How long to wait, after the git child has exited or been killed, for the
+/// pipe reader tasks to reach EOF before giving up on them. EOF requires every
+/// process holding the pipe write ends to be gone — an orphaned child of git
+/// (git-remote-https, a GCM prompt) can hold them open indefinitely.
+const GIT_READER_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Join the stdout/stderr reader tasks, but never wedge on them: if the pipes
+/// haven't reached EOF within [`GIT_READER_DRAIN_TIMEOUT`] (an orphaned child
+/// of the git process still holds the write ends), abort the readers and move
+/// on. Without this bound the caller — which holds the git process lock —
+/// blocks forever and every subsequent git operation in the app queues behind
+/// a lock that never releases.
+async fn drain_reader_tasks(
+    mut out_handle: tokio::task::JoinHandle<()>,
+    mut err_handle: tokio::task::JoinHandle<()>,
+    context: &str,
+) {
+    let drain = async {
+        let _ = (&mut out_handle).await;
+        let _ = (&mut err_handle).await;
+    };
+    if tokio::time::timeout(GIT_READER_DRAIN_TIMEOUT, drain)
+        .await
+        .is_err()
+    {
+        warn!(
+            "git output readers did not reach EOF within {:?} (an orphaned child process is \
+             likely still holding the pipes); aborting them: {}",
+            GIT_READER_DRAIN_TIMEOUT, context
+        );
+        out_handle.abort();
+        err_handle.abort();
+    }
+}
+
 /// A caller holding [`GIT_PROCESS_LOCK`], tracked purely for log diagnostics.
 struct GitLockHolder {
     /// Short description of the git op (typically the command line).
@@ -1817,12 +1852,6 @@ impl Git {
         Ok(cmd)
     }
 
-    /// Build a `git credential <action>` command. Shared by the check, reject,
-    /// and approve steps of [`Self::store_credential`].
-    fn build_credential_command(&self, action: &str) -> anyhow::Result<Command> {
-        self.build_raw_command(&["credential", action])
-    }
-
     /// Read a single value from the repo's **local** git config; `None` when
     /// the key is unset (or unreadable). Caller must hold the git process lock.
     async fn local_config_get(&self, key: &str) -> Option<String> {
@@ -1992,7 +2021,7 @@ impl Git {
             }
         }
         for user in &evict {
-            if let Ok(reject_cmd) = self.build_credential_command("reject") {
+            if let Ok(reject_cmd) = self.build_raw_command(&["credential", "reject"]) {
                 let reject_input = format!("protocol=https\nhost={host}\nusername={user}\n\n");
                 let _ =
                     crate::utils::process::run_with_stdin(reject_cmd, reject_input.into_bytes())
@@ -2006,7 +2035,7 @@ impl Git {
         // not log stdin.
         let input =
             format!("protocol=https\nhost={host}\nusername={username}\npassword={password}\n\n");
-        let approve_cmd = self.build_credential_command("approve")?;
+        let approve_cmd = self.build_raw_command(&["credential", "approve"])?;
         let approve_result =
             match crate::utils::process::run_with_stdin(approve_cmd, input.into_bytes()).await {
                 Ok(out) if out.status.success() => Ok(()),
@@ -2153,7 +2182,7 @@ impl Git {
     /// [`Self::store_credential`] to skip replacing a credential that already
     /// matches.
     async fn current_credential_password(&self, host: &str, username: &str) -> Option<String> {
-        let mut cmd = self.build_credential_command("fill").ok()?;
+        let mut cmd = self.build_raw_command(&["credential", "fill"]).ok()?;
         // Never prompt just to read the current value.
         cmd.env("GIT_TERMINAL_PROMPT", "false");
         cmd.env("GCM_INTERACTIVE", "never");
@@ -2391,6 +2420,16 @@ impl Git {
             }
         };
 
+        // Wrap the child in a kill-on-close Job Object so the watchdog below
+        // can take down git's whole process tree. Plain kill() terminates only
+        // git.exe: its children (git-remote-https, a GCM credential prompt)
+        // survive holding the pipe write ends, the reader tasks never see EOF,
+        // and the post-kill joins would wedge the process lock forever.
+        // Best-effort — None degrades to single-process kill, bounded by
+        // drain_reader_tasks.
+        #[cfg(windows)]
+        let job = crate::utils::process::ProcessTreeJob::assign(&git_proc);
+
         let stdout = git_proc.stdout.take().expect("Failed to get stdout");
         let stderr = git_proc.stderr.take().expect("Failed to get stderr");
 
@@ -2457,9 +2496,14 @@ impl Git {
                             "git command made no progress for {:?}; killing stalled process: {}",
                             idle, git_cmd_str
                         );
+                        // Kill the whole tree where we can — see the Job
+                        // Object comment at the spawn site.
+                        #[cfg(windows)]
+                        if let Some(job) = &job {
+                            job.terminate();
+                        }
                         let _ = git_proc.kill().await;
-                        let _ = out_handle.await;
-                        let _ = err_handle.await;
+                        drain_reader_tasks(out_handle, err_handle, &git_cmd_str).await;
                         bail!("Git command stalled with no progress. Check the log for details.");
                     }
                     // Still producing output recently — keep waiting.
@@ -2467,14 +2511,19 @@ impl Git {
             }
         };
 
+        // The child has exited, but a straggler it spawned could still hold
+        // the pipe write ends; closing the job (KILL_ON_JOB_CLOSE) reaps any
+        // such orphan so the drain below sees EOF instead of timing out.
+        #[cfg(windows)]
+        drop(job);
+
         // The child has exited and closed its pipes, but the spawned readers may
         // not have flushed their final lines into out_lines/err_lines yet. Join
         // them before reading the collected output below — otherwise a command
         // that succeeded (e.g. `commit-tree` printing a single SHA) can
         // intermittently yield empty captured output under load, which then
         // corrupts callers like build_snapshot_commit (`commit-tree -p ""`).
-        let _ = out_handle.await;
-        let _ = err_handle.await;
+        drain_reader_tasks(out_handle, err_handle, &git_cmd_str).await;
 
         if !status.success() {
             // git config --get <blah> has empty output with a bad exit code if the variable is

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1800,19 +1800,94 @@ impl Git {
         self.run(&["config", key, value], Opts::default()).await
     }
 
-    /// Build a `git credential <action>` command wired with this client's repo
-    /// cwd and the standard env/creation flags. Shared by the reject + approve
-    /// steps of [`Self::store_credential`].
-    fn build_credential_command(&self, action: &str) -> anyhow::Result<Command> {
+    /// Build a raw `git <args…>` command wired with this client's repo cwd and
+    /// the standard env/creation flags, bypassing [`Self::run`]. For use by
+    /// code that already holds the git process lock (`run` would re-acquire it
+    /// and deadlock); the caller spawns the child and must hold the lock for
+    /// its lifetime.
+    fn build_raw_command(&self, args: &[&str]) -> anyhow::Result<Command> {
         let mut cmd = Command::new("git");
-        cmd.args(["credential", action]);
+        cmd.args(args);
         cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
         if !self.repo_path.as_os_str().is_empty() {
-            cmd.current_dir(&self.repo_path.canonicalize()?);
+            cmd.current_dir(self.repo_path.canonicalize()?);
         }
         #[cfg(windows)]
         cmd.creation_flags(CREATE_NO_WINDOW);
         Ok(cmd)
+    }
+
+    /// Build a `git credential <action>` command. Shared by the check, reject,
+    /// and approve steps of [`Self::store_credential`].
+    fn build_credential_command(&self, action: &str) -> anyhow::Result<Command> {
+        self.build_raw_command(&["credential", action])
+    }
+
+    /// Read a single value from the repo's **local** git config; `None` when
+    /// the key is unset (or unreadable). Caller must hold the git process lock.
+    async fn local_config_get(&self, key: &str) -> Option<String> {
+        let out = self
+            .build_raw_command(&["config", "--local", "--get", key])
+            .ok()?
+            .output()
+            .await
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Write a single value into the repo's local git config. Caller must hold
+    /// the git process lock.
+    async fn local_config_set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        let out = self
+            .build_raw_command(&["config", "--local", key, value])?
+            .output()
+            .await?;
+        if !out.status.success() {
+            bail!(
+                "git config {key} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    /// Remove a key from the repo's local git config; succeeds when the key is
+    /// already absent. Caller must hold the git process lock.
+    async fn local_config_unset(&self, key: &str) -> anyhow::Result<()> {
+        let out = self
+            .build_raw_command(&["config", "--local", "--unset", key])?
+            .output()
+            .await?;
+        // Exit code 5 = "key was not set" — already the state we want.
+        if !out.status.success() && out.status.code() != Some(5) {
+            bail!(
+                "git config --unset {key} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    /// `credential.https://<host>.username` — the standard git config key that
+    /// makes git attach a username to every credential request for that URL.
+    fn credential_pin_key(host: &str) -> String {
+        format!("credential.https://{host}.username")
+    }
+
+    /// Local-config key recording the username we last seeded for `host`.
+    /// Presence marks the pin as ours (vs. one the user set themselves); the
+    /// value lets a username change evict the previously seeded entry.
+    fn seeded_username_key(host: &str) -> String {
+        format!("friendshipper.https://{host}.seededusername")
+    }
+
+    /// Local-config key preserving a user-set pin value we displaced, so
+    /// [`Self::remove_credential_pin`] can restore it.
+    fn original_username_key(host: &str) -> String {
+        format!("friendshipper.https://{host}.originalusername")
     }
 
     /// Refresh git's configured credential helper with an HTTPS credential for
@@ -1820,15 +1895,28 @@ impl Git {
     /// non-interactively instead of the helper launching a login window.
     ///
     /// First checks, non-interactively, whether the helper already serves this
-    /// exact credential for a bare `https://<host>` request (what fetch/pull/
-    /// push use). If it does, this is a no-op — we don't touch a credential
-    /// store we don't own. Only when the stored value is wrong or missing do we
-    /// replace it: evict our existing entry (`git credential reject`, targeting
-    /// the seeded username so we clear only the credential we manage and don't
-    /// disturb another github.com account the user may also have), then seed
-    /// the new one (`git credential approve`). The evict is required because a
-    /// stale entry (e.g. an expired token) otherwise shadows what we store, so a
-    /// bare-host `git fetch` keeps failing even though the seed appears to land.
+    /// exact username+password. If it does, the store is left untouched and we
+    /// only make sure the username pin (below) is in place. Otherwise we evict
+    /// the entries we manage (`git credential reject` — the current username,
+    /// plus the previously seeded username when it changed, e.g. the
+    /// `x-access-token` fallback from an offline launch after the real login
+    /// becomes known; never any other account the user has stored), then seed
+    /// the new credential (`git credential approve`). The evict is required
+    /// because a stale entry (e.g. an expired token) otherwise shadows what we
+    /// store, so a `git fetch` keeps failing even though the seed appears to
+    /// land.
+    ///
+    /// Only after a successful approve do we pin
+    /// `credential.https://<host>.username` in the repo's local config. Git
+    /// injects that username into every credential request made from this repo
+    /// (background fetch/pull/push), so those requests target exactly the
+    /// entry we seed rather than whatever same-host entry the helper answers a
+    /// host-only lookup with — the wrong account, or a GCM account picker,
+    /// when the user also stores a personal login for the same host. Pinning
+    /// only after approve — and rolling the pin back if approve fails — means
+    /// the pin never points at a username with no stored credential. A
+    /// pre-existing pin the user set themselves is remembered and restored by
+    /// [`Self::remove_credential_pin`] when seeding is turned off.
     ///
     /// The credential is fed over **stdin** — never on the command line — so the
     /// secret never lands in process arguments, our git-output channel, or the
@@ -1860,13 +1948,20 @@ impl Git {
         // every other spawn site.
         let _git_lock = acquire_git_process_lock("git credential (check + refresh)").await;
 
-        // If the helper already serves exactly this credential for a bare-host
-        // request, there's nothing to do. Skipping avoids churning a store we
-        // don't own — and the brief window where the reject below has removed
-        // the entry — so we mutate only when the stored value is wrong or
-        // missing.
-        if self.current_credential_password(host).await.as_deref() == Some(password) {
+        // Fast path: the helper already serves exactly this credential for
+        // this username. Leave the store alone — just make sure the pin is in
+        // place (it can be missing after an upgrade from a build that seeded
+        // without pinning).
+        if self
+            .current_credential_password(host, username)
+            .await
+            .as_deref()
+            == Some(password)
+        {
             debug!("git credential for {host} already current; leaving it untouched");
+            if let Err(e) = self.ensure_credential_username_pin(host, username).await {
+                warn!("Failed to pin credential username for {host}: {e}");
+            }
             return Ok(());
         }
 
@@ -1878,16 +1973,31 @@ impl Git {
              fetch/pull/push/lfs authenticate without an interactive login."
         );
 
-        // Step 1 — evict our entry. Target the specific username so we clear
-        // only the credential we manage, not another github.com account the
-        // user may also have stored. Best-effort: `reject` is a no-op when
-        // nothing matches, and a hiccup here must not block re-seeding, so its
-        // result is intentionally ignored. No secret involved (protocol + host
-        // + username only).
-        if let Ok(reject_cmd) = self.build_credential_command("reject") {
-            let reject_input = format!("protocol=https\nhost={host}\nusername={username}\n\n");
-            let _ =
-                crate::utils::process::run_with_stdin(reject_cmd, reject_input.into_bytes()).await;
+        // Step 1 — evict the entries we manage. Target specific usernames so
+        // we never clear another account the user has stored: the current
+        // username, plus the one we seeded previously (recorded in local
+        // config) when it differs — otherwise a username flip (x-access-token
+        // fallback ↔ real login) strands the old PAT-bearing entry in the
+        // store forever. Best-effort: `reject` is a no-op when nothing
+        // matches, and a hiccup here must not block re-seeding, so its result
+        // is intentionally ignored. No secret involved (protocol + host +
+        // username only).
+        let mut evict = vec![username.to_string()];
+        if let Some(prev) = self
+            .local_config_get(&Self::seeded_username_key(host))
+            .await
+        {
+            if prev != username && !prev.is_empty() {
+                evict.push(prev);
+            }
+        }
+        for user in &evict {
+            if let Ok(reject_cmd) = self.build_credential_command("reject") {
+                let reject_input = format!("protocol=https\nhost={host}\nusername={user}\n\n");
+                let _ =
+                    crate::utils::process::run_with_stdin(reject_cmd, reject_input.into_bytes())
+                        .await;
+            }
         }
 
         // Step 2 — seed. git's credential protocol: key=value lines terminated
@@ -1897,27 +2007,157 @@ impl Git {
         let input =
             format!("protocol=https\nhost={host}\nusername={username}\npassword={password}\n\n");
         let approve_cmd = self.build_credential_command("approve")?;
-        let output = crate::utils::process::run_with_stdin(approve_cmd, input.into_bytes()).await?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("git credential approve failed: {}", stderr.trim());
+        let approve_result =
+            match crate::utils::process::run_with_stdin(approve_cmd, input.into_bytes()).await {
+                Ok(out) if out.status.success() => Ok(()),
+                Ok(out) => Err(anyhow::anyhow!(
+                    "git credential approve failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                )),
+                Err(e) => Err(e),
+            };
+        if let Err(e) = approve_result {
+            // The eviction above may have removed the only entry the pin
+            // points at; roll the pin back so git isn't left steering every
+            // request at a username with no stored credential.
+            if let Err(unpin_err) = self.remove_credential_pin_locked(host).await {
+                warn!("Failed to roll back credential pin for {host}: {unpin_err}");
+            }
+            return Err(e);
+        }
+
+        // Step 3 — pin the username, now that a matching credential is known
+        // to be stored. Best-effort: with the pin missing, behavior degrades
+        // to the pre-pin host-only lookup, which still works for the common
+        // single-account store.
+        if let Err(e) = self.ensure_credential_username_pin(host, username).await {
+            warn!("Failed to pin credential username for {host}: {e}");
         }
 
         info!("Stored git credential for {host} refreshed (username: {username})");
         Ok(())
     }
 
-    /// Password the configured credential helper currently serves for a bare
-    /// `https://<host>` request (what git-remote-https uses), or `None` if
-    /// nothing is stored. Runs non-interactively, so the check itself can never
-    /// launch a credential prompt. Used by [`Self::store_credential`] to skip
-    /// replacing a credential that already matches.
-    async fn current_credential_password(&self, host: &str) -> Option<String> {
+    /// Pin `credential.https://<host>.username` in the repo's local config so
+    /// git attaches `username` to every credential request it makes from this
+    /// repo (fetch/pull/push and `git credential fill` alike). This is what
+    /// disambiguates our seeded entry from any other account the user has
+    /// stored for the same host. Standard git config — honored by every
+    /// credential helper, not just GCM.
+    ///
+    /// Alongside the pin, the seeded username is recorded under a
+    /// `friendshipper.*` key so later calls can tell our pin from one the user
+    /// set themselves: a
+    /// foreign value is preserved (once) under a second key and restored by
+    /// [`Self::remove_credential_pin`], and a username change lets
+    /// [`Self::store_credential`] evict the previously seeded entry.
+    ///
+    /// Read-compares before writing so repeat calls don't rewrite .git/config.
+    /// No-op when this client has no repo path (nowhere to pin). Caller must
+    /// hold the git process lock; runs raw commands rather than [`Self::run`]
+    /// because `run` would re-acquire that lock and deadlock.
+    async fn ensure_credential_username_pin(
+        &self,
+        host: &str,
+        username: &str,
+    ) -> anyhow::Result<()> {
+        if self.repo_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        let pin_key = Self::credential_pin_key(host);
+        let marker_key = Self::seeded_username_key(host);
+
+        let current_pin = self.local_config_get(&pin_key).await;
+        let marker = self.local_config_get(&marker_key).await;
+
+        if current_pin.as_deref() == Some(username) {
+            // Pin already correct; just make sure ownership is recorded.
+            if marker.as_deref() != Some(username) {
+                self.local_config_set(&marker_key, username).await?;
+            }
+            return Ok(());
+        }
+
+        if let Some(existing) = current_pin {
+            // A pin that isn't the one we last wrote is the user's own config
+            // (e.g. their multi-account disambiguation). Remember it — once —
+            // so remove_credential_pin can put it back.
+            if marker.as_deref() != Some(existing.as_str())
+                && self
+                    .local_config_get(&Self::original_username_key(host))
+                    .await
+                    .is_none()
+            {
+                self.local_config_set(&Self::original_username_key(host), &existing)
+                    .await?;
+            }
+        }
+
+        self.local_config_set(&pin_key, username).await?;
+        self.local_config_set(&marker_key, username).await?;
+        info!("Pinned {pin_key}={username} in local git config");
+        Ok(())
+    }
+
+    /// Undo [`Self::store_credential`]'s username pin: if the current pin is
+    /// the one we wrote, restore the value the user had before we first
+    /// overwrote it (or drop the key when there was none), then clear our
+    /// bookkeeping. A pin the user has since changed themselves is left alone.
+    /// The seeded credential itself stays in the helper's store — from here on
+    /// git's credential machinery is simply not touched. Safe to call when
+    /// nothing was ever pinned. Used when the user turns credential seeding
+    /// off.
+    pub async fn remove_credential_pin(&self, host: &str) -> anyhow::Result<()> {
+        if self.repo_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        let _git_lock = acquire_git_process_lock("git config (remove credential pin)").await;
+        self.remove_credential_pin_locked(host).await
+    }
+
+    /// Body of [`Self::remove_credential_pin`] for callers that already hold
+    /// the git process lock (also used by [`Self::store_credential`] to roll
+    /// back after a failed approve).
+    async fn remove_credential_pin_locked(&self, host: &str) -> anyhow::Result<()> {
+        if self.repo_path.as_os_str().is_empty() {
+            return Ok(());
+        }
+        let marker_key = Self::seeded_username_key(host);
+        let Some(marker) = self.local_config_get(&marker_key).await else {
+            // We never pinned this repo — nothing to undo.
+            return Ok(());
+        };
+        let pin_key = Self::credential_pin_key(host);
+        let original_key = Self::original_username_key(host);
+
+        if self.local_config_get(&pin_key).await.as_deref() == Some(marker.as_str()) {
+            match self.local_config_get(&original_key).await {
+                Some(original) => self.local_config_set(&pin_key, &original).await?,
+                None => self.local_config_unset(&pin_key).await?,
+            }
+        }
+        // A pin that no longer matches the marker was changed by the user
+        // after we wrote it — theirs to keep. Either way our bookkeeping goes.
+        self.local_config_unset(&marker_key).await?;
+        self.local_config_unset(&original_key).await?;
+        info!("Removed seeded credential username pin for {host}");
+        Ok(())
+    }
+
+    /// Password the configured credential helper currently serves for
+    /// `username` at `https://<host>`, or `None` if nothing is stored. The
+    /// username is passed explicitly rather than relying on the config pin, so
+    /// the check is meaningful even before the pin lands (the pin is written
+    /// only after a successful seed). Runs non-interactively, so the check
+    /// itself can never launch a credential prompt. Used by
+    /// [`Self::store_credential`] to skip replacing a credential that already
+    /// matches.
+    async fn current_credential_password(&self, host: &str, username: &str) -> Option<String> {
         let mut cmd = self.build_credential_command("fill").ok()?;
         // Never prompt just to read the current value.
         cmd.env("GIT_TERMINAL_PROMPT", "false");
         cmd.env("GCM_INTERACTIVE", "never");
-        let input = format!("protocol=https\nhost={host}\n\n");
+        let input = format!("protocol=https\nhost={host}\nusername={username}\n\n");
         let output = crate::utils::process::run_with_stdin(cmd, input.into_bytes())
             .await
             .ok()?;
@@ -2365,29 +2605,16 @@ mod tests {
         (git, dir)
     }
 
-    // store_credential must (a) evict any stale host-level credential and
-    // (b) make the new one retrievable via git's own credential plumbing —
-    // that's the whole point of seeding the PAT so network git stops prompting.
-    // We point credential.helper at a throwaway file (never the user's real
-    // store), pre-seed a STALE credential, call store_credential, then
-    // `git credential fill` and assert the stale value is gone and the new
-    // username/password come back. Also covers the empty-username fallback to
-    // `x-access-token`, so git never gets an incomplete credential it would
-    // prompt to complete.
-    #[tokio::test]
-    async fn test_store_credential_evicts_stale_then_seeds() {
-        use std::io::Write;
-        use std::process::Stdio;
-
-        let (git, dir) = setup_repo();
-
-        // Isolate from the developer's real credential helper (e.g. a global
-        // GCM): an empty `credential.helper` value resets the inherited helper
-        // list, so only the throwaway `store` helper added afterward runs for
-        // this repo. Without the reset, git consults the global helper too and
-        // both `approve` (touching the real store!) and `fill` (shadowing our
-        // seeded value with the real one) would leak across the test boundary.
-        let cred_file = dir.path().join("creds");
+    /// Point the repo's credential.helper at a throwaway `store` file so
+    /// credential tests never touch the developer's real helper (e.g. a global
+    /// GCM): an empty `credential.helper` value resets the inherited helper
+    /// list, so only the throwaway `store` helper added afterward runs for
+    /// this repo. Without the reset, git consults the global helper too and
+    /// both `approve` (touching the real store!) and `fill` (shadowing our
+    /// seeded value with the real one) would leak across the test boundary.
+    /// Returns the path of the credential file backing the `store` helper.
+    fn isolate_credential_helper(git: &Git, dir: &std::path::Path) -> std::path::PathBuf {
+        let cred_file = dir.join("creds");
         let helper = format!(
             "store --file={}",
             cred_file.to_string_lossy().replace('\\', "/")
@@ -2403,48 +2630,82 @@ mod tests {
                 .expect("set credential.helper");
             assert!(out.status.success());
         }
+        cred_file
+    }
+
+    /// Read a key from the repo's local git config; `None` when unset.
+    fn local_config(git: &Git, key: &str) -> Option<String> {
+        let out = StdCommand::new("git")
+            .args(["config", "--local", "--get", key])
+            .current_dir(&git.repo_path)
+            .output()
+            .expect("git config --get");
+        if out.status.success() {
+            Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Set a key in the repo's local git config.
+    fn set_local_config(git: &Git, key: &str, value: &str) {
+        let out = StdCommand::new("git")
+            .args(["config", "--local", key, value])
+            .current_dir(&git.repo_path)
+            .output()
+            .expect("git config set");
+        assert!(out.status.success(), "git config {key} failed");
+    }
+
+    /// Run `git credential <action>` in the repo with `input` on stdin and
+    /// return stdout. Asserts the command succeeds.
+    fn run_credential(git: &Git, action: &str, input: &[u8]) -> String {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let mut child = StdCommand::new("git")
+            .args(["credential", action])
+            .current_dir(&git.repo_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|e| panic!("spawn git credential {action}: {e}"));
+        child.stdin.take().unwrap().write_all(input).unwrap();
+        let out = child.wait_with_output().expect("credential output");
+        assert!(out.status.success(), "git credential {action} failed");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    // store_credential must (a) evict any stale host-level credential and
+    // (b) make the new one retrievable via git's own credential plumbing —
+    // that's the whole point of seeding the PAT so network git stops prompting.
+    // We point credential.helper at a throwaway file (never the user's real
+    // store), pre-seed a STALE credential, call store_credential, then
+    // `git credential fill` and assert the stale value is gone and the new
+    // username/password come back. Also covers the empty-username fallback to
+    // `x-access-token`, so git never gets an incomplete credential it would
+    // prompt to complete.
+    #[tokio::test]
+    async fn test_store_credential_evicts_stale_then_seeds() {
+        let (git, dir) = setup_repo();
+        isolate_credential_helper(&git, dir.path());
 
         // Pre-seed a STALE credential under the same username we manage
         // (x-access-token, the empty-username fallback) but an old password, so
         // we can prove store_credential's targeted reject evicts it before
         // writing the new one rather than leaving the stale value shadowing ours.
-        let mut stale = StdCommand::new("git")
-            .args(["credential", "approve"])
-            .current_dir(&git.repo_path)
-            .stdin(Stdio::piped())
-            .spawn()
-            .expect("spawn pre-seed approve");
-        stale
-            .stdin
-            .take()
-            .unwrap()
-            .write_all(
-                b"protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghp_STALEvalue\n\n",
-            )
-            .unwrap();
-        assert!(stale.wait().expect("pre-seed approve").success());
+        run_credential(
+            &git,
+            "approve",
+            b"protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghp_STALEvalue\n\n",
+        );
 
         // Empty username must fall back to x-access-token.
         git.store_credential("github.com", "", "ghp_seededtoken")
             .await
             .expect("store_credential");
 
-        let mut child = StdCommand::new("git")
-            .args(["credential", "fill"])
-            .current_dir(&git.repo_path)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("spawn git credential fill");
-        child
-            .stdin
-            .take()
-            .unwrap()
-            .write_all(b"protocol=https\nhost=github.com\n\n")
-            .unwrap();
-        let out = child.wait_with_output().expect("fill output");
-        assert!(out.status.success());
-        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stdout = run_credential(&git, "fill", b"protocol=https\nhost=github.com\n\n");
         assert!(
             stdout.contains("password=ghp_seededtoken"),
             "fill did not return seeded password: {stdout}"
@@ -2463,26 +2724,222 @@ mod tests {
         git.store_credential("github.com", "", "ghp_seededtoken")
             .await
             .expect("store_credential (idempotent)");
-        let mut child = StdCommand::new("git")
-            .args(["credential", "fill"])
-            .current_dir(&git.repo_path)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("spawn git credential fill");
-        child
-            .stdin
-            .take()
-            .unwrap()
-            .write_all(b"protocol=https\nhost=github.com\n\n")
-            .unwrap();
-        let out = child.wait_with_output().expect("fill output");
-        assert!(out.status.success());
-        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stdout = run_credential(&git, "fill", b"protocol=https\nhost=github.com\n\n");
         assert!(
             stdout.contains("password=ghp_seededtoken"),
             "credential not intact after idempotent re-seed: {stdout}"
         );
+    }
+
+    // Regression for the check/set key mismatch flagged in review of the
+    // credential seeding: `approve` writes a username-qualified entry, but a
+    // fetch (and the pre-check inside store_credential) ask the helper with
+    // host only. With a SECOND account stored for the same host, the host-only
+    // answer can be the other account — the pre-check then never matches
+    // (reject/approve churn on every call) and a real fetch can authenticate
+    // as the wrong user. store_credential now pins
+    // `credential.https://<host>.username` in the repo's local config, making
+    // git attach our username to every credential request from this repo.
+    #[tokio::test]
+    async fn test_store_credential_two_accounts_pins_username() {
+        let (git, dir) = setup_repo();
+        let cred_file = isolate_credential_helper(&git, dir.path());
+
+        // The user's own account, stored FIRST: the `store` helper answers a
+        // host-only lookup with the first file match, so without the username
+        // pin this entry would shadow ours.
+        run_credential(
+            &git,
+            "approve",
+            b"protocol=https\nhost=github.com\nusername=personal-user\npassword=ghp_personalsecret\n\n",
+        );
+
+        git.store_credential("github.com", "f11r-bot", "ghp_botsecret")
+            .await
+            .expect("store_credential");
+
+        // The pin must land in local config.
+        let out = StdCommand::new("git")
+            .args([
+                "config",
+                "--local",
+                "--get",
+                "credential.https://github.com.username",
+            ])
+            .current_dir(&git.repo_path)
+            .output()
+            .expect("git config --get");
+        assert!(out.status.success(), "credential username was not pinned");
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "f11r-bot");
+
+        // A host-only fill — exactly what git-remote-https issues during a
+        // fetch — must resolve to OUR account via the pinned username, even
+        // though the personal account sits first in the store.
+        let stdout = run_credential(&git, "fill", b"protocol=https\nhost=github.com\n\n");
+        assert!(
+            stdout.contains("username=f11r-bot") && stdout.contains("password=ghp_botsecret"),
+            "host-only fill did not resolve to the pinned account: {stdout}"
+        );
+        assert!(
+            !stdout.contains("ghp_personalsecret"),
+            "host-only fill leaked the other account's credential: {stdout}"
+        );
+
+        // The user's own account must survive untouched — the reject inside
+        // store_credential targets only the username we manage.
+        let stdout = run_credential(
+            &git,
+            "fill",
+            b"protocol=https\nhost=github.com\nusername=personal-user\n\n",
+        );
+        assert!(
+            stdout.contains("password=ghp_personalsecret"),
+            "the user's own credential was disturbed: {stdout}"
+        );
+
+        // A repeat call must hit the "already current" fast path even with the
+        // second account present — this is the churn the pin exists to stop.
+        // No reject/approve ran iff the backing store file is byte-identical.
+        let before = std::fs::read(&cred_file).expect("read creds before");
+        git.store_credential("github.com", "f11r-bot", "ghp_botsecret")
+            .await
+            .expect("store_credential (repeat)");
+        let after = std::fs::read(&cred_file).expect("read creds after");
+        assert_eq!(
+            before, after,
+            "repeat store_credential churned the credential store instead of no-opping"
+        );
+    }
+
+    // A seeded-username flip (the x-access-token fallback from an offline
+    // launch → the real login once GitHub is reachable) must not strand the
+    // previously seeded PAT-bearing entry in the store: store_credential
+    // records the username it seeded in local config and evicts that entry
+    // when the username changes.
+    #[tokio::test]
+    async fn test_store_credential_username_change_evicts_old_entry() {
+        let (git, dir) = setup_repo();
+        let cred_file = isolate_credential_helper(&git, dir.path());
+
+        // Offline launch: empty username falls back to x-access-token.
+        git.store_credential("github.com", "", "ghp_token")
+            .await
+            .expect("first seed");
+        let creds = std::fs::read_to_string(&cred_file).expect("read creds");
+        assert!(
+            creds.contains("x-access-token"),
+            "fallback entry missing: {creds}"
+        );
+
+        // Same PAT, real login now known.
+        git.store_credential("github.com", "real-login", "ghp_token")
+            .await
+            .expect("second seed");
+
+        let creds = std::fs::read_to_string(&cred_file).expect("read creds");
+        assert!(creds.contains("real-login"), "new entry missing: {creds}");
+        assert!(
+            !creds.contains("x-access-token"),
+            "old seeded entry was stranded in the store: {creds}"
+        );
+
+        // Pin follows the new username.
+        let stdout = run_credential(&git, "fill", b"protocol=https\nhost=github.com\n\n");
+        assert!(
+            stdout.contains("username=real-login"),
+            "pin did not move to the new username: {stdout}"
+        );
+    }
+
+    // Turning seeding off must hand git auth back to the user:
+    // remove_credential_pin restores a pin the user had set themselves before
+    // we displaced it, drops the pin entirely when there was none, leaves a
+    // pin the user changed after our seed alone, and touches nothing when we
+    // never pinned.
+    #[tokio::test]
+    async fn test_remove_credential_pin_restores_user_config() {
+        const PIN: &str = "credential.https://github.com.username";
+        const MARKER: &str = "friendshipper.https://github.com.seededusername";
+        const ORIGINAL: &str = "friendshipper.https://github.com.originalusername";
+
+        // Case 1: the user had their own pin — seeding displaces it (recording
+        // the original), unpinning restores it.
+        {
+            let (git, dir) = setup_repo();
+            isolate_credential_helper(&git, dir.path());
+            set_local_config(&git, PIN, "personal-user");
+            git.store_credential("github.com", "f11r-bot", "ghp_tok")
+                .await
+                .expect("seed");
+            assert_eq!(local_config(&git, PIN).as_deref(), Some("f11r-bot"));
+            assert_eq!(
+                local_config(&git, ORIGINAL).as_deref(),
+                Some("personal-user")
+            );
+            git.remove_credential_pin("github.com")
+                .await
+                .expect("unpin");
+            assert_eq!(
+                local_config(&git, PIN).as_deref(),
+                Some("personal-user"),
+                "user's own pin was not restored"
+            );
+            assert!(
+                local_config(&git, MARKER).is_none() && local_config(&git, ORIGINAL).is_none(),
+                "seeded-username bookkeeping survived the unpin"
+            );
+        }
+
+        // Case 2: no pre-existing pin — unpinning drops the key entirely.
+        {
+            let (git, dir) = setup_repo();
+            isolate_credential_helper(&git, dir.path());
+            git.store_credential("github.com", "f11r-bot", "ghp_tok")
+                .await
+                .expect("seed");
+            assert_eq!(local_config(&git, PIN).as_deref(), Some("f11r-bot"));
+            git.remove_credential_pin("github.com")
+                .await
+                .expect("unpin");
+            assert!(local_config(&git, PIN).is_none(), "our pin was not removed");
+        }
+
+        // Case 3: the user changed the pin after our seed — theirs to keep.
+        {
+            let (git, dir) = setup_repo();
+            isolate_credential_helper(&git, dir.path());
+            git.store_credential("github.com", "f11r-bot", "ghp_tok")
+                .await
+                .expect("seed");
+            set_local_config(&git, PIN, "changed-later");
+            git.remove_credential_pin("github.com")
+                .await
+                .expect("unpin");
+            assert_eq!(
+                local_config(&git, PIN).as_deref(),
+                Some("changed-later"),
+                "unpin clobbered a pin the user changed after our seed"
+            );
+            assert!(
+                local_config(&git, MARKER).is_none(),
+                "seeded-username bookkeeping survived the unpin"
+            );
+        }
+
+        // Case 4: we never pinned — a user-set pin must be left untouched.
+        {
+            let (git, dir) = setup_repo();
+            isolate_credential_helper(&git, dir.path());
+            set_local_config(&git, PIN, "personal-user");
+            git.remove_credential_pin("github.com")
+                .await
+                .expect("unpin (no-op)");
+            assert_eq!(
+                local_config(&git, PIN).as_deref(),
+                Some("personal-user"),
+                "unpin touched a pin we never wrote"
+            );
+        }
     }
 
     // Regression: startup maintenance expired reflogs with the expiry window

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1823,11 +1823,12 @@ impl Git {
     /// exact credential for a bare `https://<host>` request (what fetch/pull/
     /// push use). If it does, this is a no-op — we don't touch a credential
     /// store we don't own. Only when the stored value is wrong or missing do we
-    /// replace it: evict the stale host-level entry (`git credential reject`
-    /// with no username), then seed the new one (`git credential approve`). The
-    /// evict is required because a stale entry (e.g. an expired GCM OAuth token)
-    /// otherwise shadows what we store, so a bare-host `git fetch` keeps failing
-    /// even though the seed appears to land.
+    /// replace it: evict our existing entry (`git credential reject`, targeting
+    /// the seeded username so we clear only the credential we manage and don't
+    /// disturb another github.com account the user may also have), then seed
+    /// the new one (`git credential approve`). The evict is required because a
+    /// stale entry (e.g. an expired token) otherwise shadows what we store, so a
+    /// bare-host `git fetch` keeps failing even though the seed appears to land.
     ///
     /// The credential is fed over **stdin** — never on the command line — so the
     /// secret never lands in process arguments, our git-output channel, or the
@@ -1873,15 +1874,18 @@ impl Git {
         // credential changed. Host + username only — never the password.
         info!(
             "Refreshing git credential for {host} from the saved PAT (username: {username}): \
-             evicting the stale host-level entry, then re-seeding the credential helper so \
-             background fetch/pull/push/lfs authenticate without an interactive login."
+             evicting our stale entry, then re-seeding the credential helper so background \
+             fetch/pull/push/lfs authenticate without an interactive login."
         );
 
-        // Step 1 — evict. Best-effort: `reject` is a no-op when nothing is
-        // stored, and a hiccup here must not block re-seeding, so its result is
-        // intentionally ignored. No secret involved — only protocol + host.
+        // Step 1 — evict our entry. Target the specific username so we clear
+        // only the credential we manage, not another github.com account the
+        // user may also have stored. Best-effort: `reject` is a no-op when
+        // nothing matches, and a hiccup here must not block re-seeding, so its
+        // result is intentionally ignored. No secret involved (protocol + host
+        // + username only).
         if let Ok(reject_cmd) = self.build_credential_command("reject") {
-            let reject_input = format!("protocol=https\nhost={host}\n\n");
+            let reject_input = format!("protocol=https\nhost={host}\nusername={username}\n\n");
             let _ =
                 crate::utils::process::run_with_stdin(reject_cmd, reject_input.into_bytes()).await;
         }
@@ -2400,10 +2404,10 @@ mod tests {
             assert!(out.status.success());
         }
 
-        // Pre-seed a STALE credential for the host so we can prove
-        // store_credential evicts it (the reject step) before writing the new
-        // one — rather than leaving the stale value shadowing ours, which is the
-        // exact failure mode this hardening fixes.
+        // Pre-seed a STALE credential under the same username we manage
+        // (x-access-token, the empty-username fallback) but an old password, so
+        // we can prove store_credential's targeted reject evicts it before
+        // writing the new one rather than leaving the stale value shadowing ours.
         let mut stale = StdCommand::new("git")
             .args(["credential", "approve"])
             .current_dir(&git.repo_path)
@@ -2415,7 +2419,7 @@ mod tests {
             .take()
             .unwrap()
             .write_all(
-                b"protocol=https\nhost=github.com\nusername=staleuser\npassword=ghp_STALEvalue\n\n",
+                b"protocol=https\nhost=github.com\nusername=x-access-token\npassword=ghp_STALEvalue\n\n",
             )
             .unwrap();
         assert!(stale.wait().expect("pre-seed approve").success());

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1712,16 +1712,41 @@ impl Git {
         self.run(&["config", key, value], Opts::default()).await
     }
 
-    /// Seed git's configured credential helper with an HTTPS credential for
+    /// Build a `git credential <action>` command wired with this client's repo
+    /// cwd and the standard env/creation flags. Shared by the reject + approve
+    /// steps of [`Self::store_credential`].
+    fn build_credential_command(&self, action: &str) -> anyhow::Result<Command> {
+        let mut cmd = Command::new("git");
+        cmd.args(["credential", action]);
+        cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
+        if !self.repo_path.as_os_str().is_empty() {
+            cmd.current_dir(&self.repo_path.canonicalize()?);
+        }
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        Ok(cmd)
+    }
+
+    /// Refresh git's configured credential helper with an HTTPS credential for
     /// `host`, so subsequent network git operations authenticate
     /// non-interactively instead of the helper launching a login window.
     ///
-    /// The credential is fed to `git credential approve` over **stdin** — never
-    /// on the command line — so the secret never lands in process arguments,
-    /// our git-output channel, or the logs. Whatever helper the user has
-    /// configured (e.g. Git Credential Manager) performs the actual storage,
-    /// keyed by host; re-seeding overwrites whatever it had cached, including a
-    /// stale credential the helper erased after a prior 401.
+    /// Two steps, in order:
+    /// 1. **Evict** any existing host-level credential for `host`
+    ///    (`git credential reject` with no username). This is the crucial part:
+    ///    git-remote-https (fetch/pull/push) asks the helper for
+    ///    `https://<host>` with *no* username, and a stale entry sitting there —
+    ///    e.g. an expired GCM OAuth token — shadows whatever we store next, so
+    ///    the seed appears to land in the credential store yet fetches keep
+    ///    failing. Rejecting first mirrors clearing the credential by hand,
+    ///    which is what makes the new credential actually resolve for a
+    ///    bare-host fetch.
+    /// 2. **Seed** the new credential (`git credential approve`).
+    ///
+    /// The credential is fed over **stdin** — never on the command line — so the
+    /// secret never lands in process arguments, our git-output channel, or the
+    /// logs. Whatever helper the user has configured (e.g. Git Credential
+    /// Manager) performs the actual storage.
     ///
     /// This is how a non-expiring PAT held in the app keyring becomes *git's*
     /// credential (the in-app PAT otherwise only feeds the GitHub HTTP API,
@@ -1730,8 +1755,8 @@ impl Git {
     /// back to the conventional `x-access-token` rather than leaving git with
     /// an incomplete credential it would prompt to fill.
     ///
-    /// Best-effort: if no credential helper is configured, `git credential
-    /// approve` is a no-op and this returns `Ok`.
+    /// Best-effort: if no credential helper is configured, the underlying git
+    /// commands are no-ops and this returns `Ok`.
     pub async fn store_credential(
         &self,
         host: &str,
@@ -1744,32 +1769,42 @@ impl Git {
             username
         };
 
-        // git's credential protocol: key=value lines terminated by a blank
-        // line. The password line carries the secret; everything below treats
-        // `input` as sensitive (no logging, fed only via stdin).
+        // Narrate the action + its effect so the logs explain why a stored
+        // credential changed out from under the user. Host + username only —
+        // never the password.
+        info!(
+            "Refreshing git credential for {host} from the saved PAT (username: {username}): \
+             evicting any stale host-level entry, then re-seeding the credential helper so \
+             background fetch/pull/push/lfs authenticate without an interactive login."
+        );
+
+        // Spawns git processes (and the helper), so hold the process lock for
+        // the whole reject + approve pair like every other spawn site.
+        let _git_lock = acquire_git_process_lock().await;
+
+        // Step 1 — evict. Best-effort: `reject` is a no-op when nothing is
+        // stored, and a hiccup here must not block re-seeding, so its result is
+        // intentionally ignored. No secret involved — only protocol + host.
+        if let Ok(reject_cmd) = self.build_credential_command("reject") {
+            let reject_input = format!("protocol=https\nhost={host}\n\n");
+            let _ =
+                crate::utils::process::run_with_stdin(reject_cmd, reject_input.into_bytes()).await;
+        }
+
+        // Step 2 — seed. git's credential protocol: key=value lines terminated
+        // by a blank line. The password line carries the secret; `input` is
+        // sensitive (fed only via stdin, never logged). `run_with_stdin` does
+        // not log stdin.
         let input =
             format!("protocol=https\nhost={host}\nusername={username}\npassword={password}\n\n");
-
-        let mut cmd = Command::new("git");
-        cmd.args(["credential", "approve"]);
-        cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
-        if !self.repo_path.as_os_str().is_empty() {
-            cmd.current_dir(&self.repo_path.canonicalize()?);
-        }
-        #[cfg(windows)]
-        cmd.creation_flags(CREATE_NO_WINDOW);
-
-        // Note: host + username only — never the password.
-        info!("Seeding git credential for host {host} (username: {username})");
-
-        // Spawns a git process (and the helper), so hold the process lock like
-        // every other spawn site. `run_with_stdin` does not log stdin.
-        let _git_lock = acquire_git_process_lock().await;
-        let output = crate::utils::process::run_with_stdin(cmd, input.into_bytes()).await?;
+        let approve_cmd = self.build_credential_command("approve")?;
+        let output = crate::utils::process::run_with_stdin(approve_cmd, input.into_bytes()).await?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!("git credential approve failed: {}", stderr.trim());
         }
+
+        info!("Stored git credential for {host} refreshed (username: {username})");
         Ok(())
     }
 
@@ -2191,15 +2226,17 @@ mod tests {
         (git, dir)
     }
 
-    // store_credential must actually make the credential retrievable via git's
-    // own credential plumbing — that's the whole point of seeding the PAT so
-    // network git stops prompting. We point credential.helper at a throwaway
-    // file (never the user's real store), seed a token, then `git credential
-    // fill` and assert the seeded username/password come back. Also covers the
-    // empty-username fallback to `x-access-token`, so git never gets an
-    // incomplete credential it would prompt to complete.
+    // store_credential must (a) evict any stale host-level credential and
+    // (b) make the new one retrievable via git's own credential plumbing —
+    // that's the whole point of seeding the PAT so network git stops prompting.
+    // We point credential.helper at a throwaway file (never the user's real
+    // store), pre-seed a STALE credential, call store_credential, then
+    // `git credential fill` and assert the stale value is gone and the new
+    // username/password come back. Also covers the empty-username fallback to
+    // `x-access-token`, so git never gets an incomplete credential it would
+    // prompt to complete.
     #[tokio::test]
-    async fn test_store_credential_is_retrievable_via_fill() {
+    async fn test_store_credential_evicts_stale_then_seeds() {
         use std::io::Write;
         use std::process::Stdio;
 
@@ -2227,6 +2264,26 @@ mod tests {
                 .expect("set credential.helper");
             assert!(out.status.success());
         }
+
+        // Pre-seed a STALE credential for the host so we can prove
+        // store_credential evicts it (the reject step) before writing the new
+        // one — rather than leaving the stale value shadowing ours, which is the
+        // exact failure mode this hardening fixes.
+        let mut stale = StdCommand::new("git")
+            .args(["credential", "approve"])
+            .current_dir(&git.repo_path)
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("spawn pre-seed approve");
+        stale
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(
+                b"protocol=https\nhost=github.com\nusername=staleuser\npassword=ghp_STALEvalue\n\n",
+            )
+            .unwrap();
+        assert!(stale.wait().expect("pre-seed approve").success());
 
         // Empty username must fall back to x-access-token.
         git.store_credential("github.com", "", "ghp_seededtoken")
@@ -2256,6 +2313,10 @@ mod tests {
         assert!(
             stdout.contains("username=x-access-token"),
             "fill did not return fallback username: {stdout}"
+        );
+        assert!(
+            !stdout.contains("ghp_STALEvalue"),
+            "stale credential was not evicted before seeding: {stdout}"
         );
     }
 

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -202,11 +202,24 @@ pub fn parse_bool_string(bool_str: &str) -> anyhow::Result<bool> {
     bail!("Unable to parse string")
 }
 
+/// Wall-clock backstop for a single `git` subprocess. Because every git
+/// process now holds [`GIT_PROCESS_LOCK`] for its whole lifetime, a hung
+/// process — a stuck credential prompt, or a dead connection that never makes
+/// progress — would otherwise hold the lock forever and wedge *every* git
+/// operation in the app. The runner kills such a process so the lock is
+/// released and callers get an error. Set generously so it never trips a
+/// legitimately long op (large fetch, gc/repack). NOTE: a fresh full clone of
+/// a very large repo over a slow link can legitimately exceed this — bump it
+/// or special-case `clone` if that ever bites.
+const GIT_PROCESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// Acquire the process-wide git serialization guard. Hold the returned guard
 /// for the full lifetime of a `git` subprocess (spawn through wait). See
 /// [`GIT_PROCESS_LOCK`] for the invariant — never call this while already
-/// holding the guard.
-async fn acquire_git_process_lock() -> tokio::sync::OwnedMutexGuard<()> {
+/// holding the guard. This applies to external callers in other crates too:
+/// hold it across a single spawn+wait and never call another git-spawning
+/// function while holding it.
+pub async fn acquire_git_process_lock() -> tokio::sync::OwnedMutexGuard<()> {
     GIT_PROCESS_LOCK.clone().lock_owned().await
 }
 
@@ -1922,7 +1935,23 @@ impl Git {
             }
         });
 
-        let status = git_proc.wait().await?;
+        let status = match tokio::time::timeout(GIT_PROCESS_TIMEOUT, git_proc.wait()).await {
+            Ok(wait_result) => wait_result?,
+            Err(_elapsed) => {
+                // Exceeded the generous ceiling — almost certainly hung (a stuck
+                // credential prompt, or a dead connection making no progress).
+                // Kill it so it can't hold GIT_PROCESS_LOCK forever and wedge
+                // every other git operation in the app.
+                warn!(
+                    "git command exceeded {:?}; killing hung process: {}",
+                    GIT_PROCESS_TIMEOUT, git_cmd_str
+                );
+                let _ = git_proc.kill().await;
+                let _ = out_handle.await;
+                let _ = err_handle.await;
+                bail!("Git command timed out. Check the log for details.");
+            }
+        };
 
         // The child has exited and closed its pipes, but the spawned readers may
         // not have flushed their final lines into out_lines/err_lines yet. Join

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -124,6 +124,10 @@ pub struct Opts<'a> {
     pub return_complete_error: bool,
     pub lfs_mode: LfsMode,
     pub skip_notify_frontend: bool,
+    // When set, the git command runs with interactive credential prompts
+    // disabled. Use for background/non-user-initiated operations so a stale
+    // credential fails quietly instead of spawning a login window.
+    pub skip_interactive_auth: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -141,6 +145,7 @@ impl Default for Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 }
@@ -153,6 +158,7 @@ impl Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -163,6 +169,7 @@ impl Opts<'_> {
             return_complete_error: false,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -173,6 +180,7 @@ impl Opts<'_> {
             return_complete_error: true,
             lfs_mode: LfsMode::Inflated,
             skip_notify_frontend: false,
+            skip_interactive_auth: false,
         }
     }
 
@@ -188,6 +196,11 @@ impl Opts<'_> {
 
     pub fn with_skip_notify_frontend(mut self) -> Self {
         self.skip_notify_frontend = true;
+        self
+    }
+
+    pub fn with_skip_interactive_auth(mut self) -> Self {
+        self.skip_interactive_auth = true;
         self
     }
 }
@@ -1544,8 +1557,13 @@ impl Git {
     }
 
     pub async fn run_maintenance(&self) -> anyhow::Result<()> {
-        self.run(&["maintenance", "run", "--auto"], Opts::default())
-            .await
+        // Runs on the background maintenance loop and may prefetch over the
+        // network, so it must not trigger an interactive credential prompt.
+        self.run(
+            &["maintenance", "run", "--auto"],
+            Opts::default().with_skip_interactive_auth(),
+        )
+        .await
     }
 
     pub async fn run_gc(&self) -> anyhow::Result<()> {
@@ -1654,6 +1672,7 @@ impl Git {
                     return_complete_error: true,
                     lfs_mode: LfsMode::Stubs,
                     skip_notify_frontend: false,
+                    skip_interactive_auth: false,
                 },
             )
             .await?;
@@ -1854,6 +1873,16 @@ impl Git {
 
         // disable clone protection
         cmd.env("GIT_CLONE_PROTECTION_ACTIVE", "false");
+
+        // For background/non-user-initiated commands (e.g. the maintenance fetch
+        // loop), never allow an interactive credential prompt. If the cached
+        // credential is stale, the command fails quietly and the next
+        // user-initiated operation handles re-authentication, instead of a
+        // background loop spawning a GCM login window every few seconds.
+        if opts.skip_interactive_auth {
+            cmd.env("GIT_TERMINAL_PROMPT", "false");
+            cmd.env("GCM_INTERACTIVE", "never");
+        }
 
         if opts.lfs_mode == LfsMode::Stubs {
             cmd.env("GIT_LFS_SKIP_SMUDGE", "1");

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -1353,10 +1353,20 @@ impl Git {
     }
 
     pub async fn verify_locks(&self) -> anyhow::Result<VerifyLocksResponse> {
+        // Runs `git lfs locks`, which contacts the LFS server and so can invoke
+        // the credential helper. This is only ever called from the ambient
+        // status refresh (see StatusOp), never from a deliberate user sync, so
+        // it must not launch an interactive credential prompt: a stale
+        // credential should fail quietly here (the caller degrades to the last
+        // known lock state) and re-auth happens on the next user-initiated
+        // pull/push. Without this, a background status refresh pops a GCM
+        // login window every few seconds once the stored credential expires.
         let output = match self
             .run_and_collect_output(
                 &["lfs", "locks", "--verify", "--json"],
-                Opts::new_without_logs().with_complete_error(),
+                Opts::new_without_logs()
+                    .with_complete_error()
+                    .with_skip_interactive_auth(),
             )
             .await
         {
@@ -1373,7 +1383,7 @@ impl Git {
                 // then try again
                 self.run_and_collect_output(
                     &["lfs", "locks", "--verify", "--json"],
-                    Opts::new_without_logs(),
+                    Opts::new_without_logs().with_skip_interactive_auth(),
                 )
                 .await?
             }

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -33,6 +33,24 @@ lazy_static! {
     static ref WORKTREE_SHA_REGEX: Regex = Regex::new(r"^HEAD (.+)").unwrap();
     static ref WORKTREE_BRANCH_REGEX: Regex = Regex::new(r"^(branch|detached)\s*(.+)?").unwrap();
     static ref GIT_FETCH_LOCK: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+
+    /// Process-wide serialization gate for *every* `git` subprocess this app
+    /// spawns. Two `git` processes running concurrently against the same repo
+    /// and credential store race destructively: Git Credential Manager stomps
+    /// the stored credential (surfacing as spurious re-auth prompts), and the
+    /// index / refs / packfiles can collide. Every subprocess spawn site holds
+    /// this guard for the lifetime of its child, so the app never has two `git`
+    /// processes in flight at once. External git processes (a user's terminal,
+    /// the engine) are out of scope — `wait_for_lock` mitigates index.lock
+    /// contention with those.
+    ///
+    /// INVARIANT — this lock is NOT re-entrant (tokio's Mutex deadlocks on a
+    /// second acquire from the same task). Every acquisition site is a leaf
+    /// that spawns exactly one subprocess and never calls another acquiring
+    /// function while holding the guard. `GIT_FETCH_LOCK` is always taken
+    /// *before* this lock (in `fetch`/`refetch`) and never after, so the two
+    /// have a consistent order and cannot deadlock against each other.
+    static ref GIT_PROCESS_LOCK: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
 }
 
 #[cfg(windows)]
@@ -184,6 +202,14 @@ pub fn parse_bool_string(bool_str: &str) -> anyhow::Result<bool> {
     bail!("Unable to parse string")
 }
 
+/// Acquire the process-wide git serialization guard. Hold the returned guard
+/// for the full lifetime of a `git` subprocess (spawn through wait). See
+/// [`GIT_PROCESS_LOCK`] for the invariant — never call this while already
+/// holding the guard.
+async fn acquire_git_process_lock() -> tokio::sync::OwnedMutexGuard<()> {
+    GIT_PROCESS_LOCK.clone().lock_owned().await
+}
+
 impl Git {
     pub fn new(repo_path: PathBuf, tx: std::sync::mpsc::Sender<String>) -> Git {
         Git { repo_path, tx }
@@ -206,6 +232,9 @@ impl Git {
         #[cfg(windows)]
         log.creation_flags(CREATE_NO_WINDOW);
 
+        // Reading FETCH_HEAD/HEAD races a concurrent fetch rewriting the same
+        // ref; serialize like every other git subprocess.
+        let _git_lock = acquire_git_process_lock().await;
         let output = log.output().await?;
 
         let stdout = std::str::from_utf8(&output.stdout)?;
@@ -588,6 +617,9 @@ impl Git {
             index_file.display()
         );
 
+        // Operates on a temp index but still writes loose objects into the real
+        // .git/objects — serialize against maintenance/gc and other git procs.
+        let _git_lock = acquire_git_process_lock().await;
         let output = cmd.output().await?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1833,6 +1865,12 @@ impl Git {
         }
         info!("Running: {}", git_cmd_str);
 
+        // Serialize this subprocess against every other git process the app
+        // spawns. Held until the child exits and its stdout/stderr readers are
+        // joined below, guaranteeing no two app git processes overlap (which
+        // is what stomps GCM credentials and collides on the index/refs).
+        let _git_lock = acquire_git_process_lock().await;
+
         let out_pipe = Stdio::piped();
         let err_pipe = Stdio::piped();
 
@@ -1946,6 +1984,10 @@ pub async fn configure_global(key: &str, value: &str) -> Result<(), CoreError> {
     #[cfg(windows)]
     cmd.creation_flags(CREATE_NO_WINDOW);
 
+    // Rewrites ~/.gitconfig; a concurrent git reading global config can hit a
+    // transient access error on Windows (cf. the .git/config startup-order
+    // fix). Serialize against every other git subprocess.
+    let _git_lock = acquire_git_process_lock().await;
     let cmd_output = cmd.output().await?;
     if !cmd_output.status.success() {
         let err_output = String::from_utf8(cmd_output.stderr).unwrap_or_default();

--- a/core/src/clients/git.rs
+++ b/core/src/clients/git.rs
@@ -51,6 +51,16 @@ lazy_static! {
     /// *before* this lock (in `fetch`/`refetch`) and never after, so the two
     /// have a consistent order and cannot deadlock against each other.
     static ref GIT_PROCESS_LOCK: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+
+    /// Who currently holds [`GIT_PROCESS_LOCK`], for observability only. Set when
+    /// the guard is acquired and cleared when it drops, so a waiting caller can
+    /// name the op it's queued behind (and how long that op has held the lock)
+    /// in the logs — turning "the app feels stuck on git" into a line that says
+    /// which command is holding things up. A plain (sync) parking_lot mutex: it's
+    /// a leaf, taken only briefly and never across an `.await`, so it adds no
+    /// ordering constraints against the locks above.
+    static ref GIT_LOCK_HOLDER: parking_lot::Mutex<Option<GitLockHolder>> =
+        parking_lot::Mutex::new(None);
 }
 
 #[cfg(windows)]
@@ -238,14 +248,79 @@ const GIT_PROCESS_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// negligible overhead.
 const GIT_PROCESS_IDLE_CHECK: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// A caller holding [`GIT_PROCESS_LOCK`], tracked purely for log diagnostics.
+struct GitLockHolder {
+    /// Short description of the git op (typically the command line).
+    label: String,
+    /// When the lock was acquired, so waiters can report how long it's been held.
+    since: std::time::Instant,
+}
+
+/// If the lock is already held this long when a new caller arrives, that's a
+/// stall worth a warning (a slow sync, or an op on its way to the idle-timeout
+/// kill) rather than ordinary brief contention.
+const GIT_LOCK_SLOW_HOLD: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// RAII guard for [`GIT_PROCESS_LOCK`] that also clears [`GIT_LOCK_HOLDER`] on
+/// drop. Returned by [`acquire_git_process_lock`]; hold it for the lifetime of
+/// a single git subprocess.
+pub struct GitLockGuard {
+    // Dropped after this struct's `Drop::drop` runs, so the holder is cleared
+    // just before the mutex is released.
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl Drop for GitLockGuard {
+    fn drop(&mut self) {
+        *GIT_LOCK_HOLDER.lock() = None;
+    }
+}
+
 /// Acquire the process-wide git serialization guard. Hold the returned guard
 /// for the full lifetime of a `git` subprocess (spawn through wait). See
 /// [`GIT_PROCESS_LOCK`] for the invariant — never call this while already
 /// holding the guard. This applies to external callers in other crates too:
 /// hold it across a single spawn+wait and never call another git-spawning
 /// function while holding it.
-pub async fn acquire_git_process_lock() -> tokio::sync::OwnedMutexGuard<()> {
-    GIT_PROCESS_LOCK.clone().lock_owned().await
+///
+/// `label` names the op for diagnostics (use the git command line where you
+/// have it). When the lock is contended, the wait is logged with the op that's
+/// holding it, so a stuck or slow git operation is visible in the logs.
+pub async fn acquire_git_process_lock(label: &str) -> GitLockGuard {
+    let guard = match GIT_PROCESS_LOCK.clone().try_lock_owned() {
+        Ok(g) => g,
+        Err(_) => {
+            // Contended — name who we're queued behind. Read + drop the holder
+            // lock before awaiting (never hold a sync mutex across `.await`).
+            let held = GIT_LOCK_HOLDER
+                .lock()
+                .as_ref()
+                .map(|h| (h.label.clone(), h.since.elapsed()));
+            match held {
+                Some((holder, held_for)) if held_for >= GIT_LOCK_SLOW_HOLD => {
+                    warn!(
+                        "git op {:?} blocked: lock held by {:?} for {:?} (slow op or stall)",
+                        label, holder, held_for
+                    );
+                }
+                Some((holder, held_for)) => {
+                    debug!(
+                        "git op {:?} waiting on lock held by {:?} (held {:?})",
+                        label, holder, held_for
+                    );
+                }
+                None => {}
+            }
+            GIT_PROCESS_LOCK.clone().lock_owned().await
+        }
+    };
+
+    *GIT_LOCK_HOLDER.lock() = Some(GitLockHolder {
+        label: label.to_string(),
+        since: std::time::Instant::now(),
+    });
+
+    GitLockGuard { _guard: guard }
 }
 
 impl Git {
@@ -272,7 +347,7 @@ impl Git {
 
         // Reading FETCH_HEAD/HEAD races a concurrent fetch rewriting the same
         // ref; serialize like every other git subprocess.
-        let _git_lock = acquire_git_process_lock().await;
+        let _git_lock = acquire_git_process_lock("git log -1 (head_commit)").await;
         let output = log.output().await?;
 
         let stdout = std::str::from_utf8(&output.stdout)?;
@@ -657,7 +732,8 @@ impl Git {
 
         // Operates on a temp index but still writes loose objects into the real
         // .git/objects — serialize against maintenance/gc and other git procs.
-        let _git_lock = acquire_git_process_lock().await;
+        let _git_lock =
+            acquire_git_process_lock(&format!("git {} (temp index)", args.join(" "))).await;
         let output = cmd.output().await?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1792,7 +1868,7 @@ impl Git {
 
         // Spawns git processes (and the helper), so hold the process lock for
         // the whole reject + approve pair like every other spawn site.
-        let _git_lock = acquire_git_process_lock().await;
+        let _git_lock = acquire_git_process_lock("git credential (reject + approve)").await;
 
         // Step 1 — evict. Best-effort: `reject` is a no-op when nothing is
         // stored, and a hiccup here must not block re-seeding, so its result is
@@ -2029,7 +2105,7 @@ impl Git {
         // spawns. Held until the child exits and its stdout/stderr readers are
         // joined below, guaranteeing no two app git processes overlap (which
         // is what stomps GCM credentials and collides on the index/refs).
-        let _git_lock = acquire_git_process_lock().await;
+        let _git_lock = acquire_git_process_lock(&git_cmd_str).await;
 
         let out_pipe = Stdio::piped();
         let err_pipe = Stdio::piped();
@@ -2181,7 +2257,7 @@ pub async fn configure_global(key: &str, value: &str) -> Result<(), CoreError> {
     // Rewrites ~/.gitconfig; a concurrent git reading global config can hit a
     // transient access error on Windows (cf. the .git/config startup-order
     // fix). Serialize against every other git subprocess.
-    let _git_lock = acquire_git_process_lock().await;
+    let _git_lock = acquire_git_process_lock(&format!("git config --global {key}")).await;
     let cmd_output = cmd.output().await?;
     if !cmd_output.status.success() {
         let err_output = String::from_utf8(cmd_output.stderr).unwrap_or_default();

--- a/core/src/clients/git_maintenance_runner.rs
+++ b/core/src/clients/git_maintenance_runner.rs
@@ -12,6 +12,22 @@ pub struct GitMaintenanceRunner {
     git: Git,
     config: MaintenanceConfig,
     pause: Arc<AtomicBool>,
+    reauth_tx: Option<tokio::sync::mpsc::Sender<()>>,
+}
+
+/// Does this fetch error look like a missing/rejected credential (as opposed to
+/// a network blip)? These markers are git/HTTP-generic, not GitHub-specific.
+/// Used to decide whether a background fetch failure is worth asking the app to
+/// repopulate the credential.
+fn is_auth_error(msg: &str) -> bool {
+    const MARKERS: [&str; 5] = [
+        "could not read Username",
+        "Authentication failed",
+        "terminal prompts disabled",
+        "Cannot prompt",
+        "HTTP 401",
+    ];
+    MARKERS.iter().any(|m| msg.contains(m))
 }
 
 struct MaintenanceConfig {
@@ -34,7 +50,12 @@ impl GitMaintenanceRunner {
 
         let config = MaintenanceConfig::default();
 
-        GitMaintenanceRunner { git, pause, config }
+        GitMaintenanceRunner {
+            git,
+            pause,
+            config,
+            reauth_tx: None,
+        }
     }
 
     pub fn with_fetch_interval(mut self, interval: Duration) -> Self {
@@ -47,25 +68,48 @@ impl GitMaintenanceRunner {
         self
     }
 
+    /// Register a notifier that fires (best-effort) when a background fetch
+    /// fails with an auth error, so the app can repopulate a stomped/erased
+    /// credential without waiting for a restart. Use a small channel
+    /// (capacity 1): a full channel just means a re-seed is already pending.
+    pub fn with_reauth_notifier(mut self, tx: tokio::sync::mpsc::Sender<()>) -> Self {
+        self.reauth_tx = Some(tx);
+        self
+    }
+
     pub async fn run(&self) -> anyhow::Result<()> {
         let git = self.git.clone();
         let fetch_interval = self.config.fetch_interval;
         let pause = self.pause.clone();
+        let reauth_tx = self.reauth_tx.clone();
         let fetch_task = tokio::task::spawn(async move {
             loop {
                 if !pause.clone().load(std::sync::atomic::Ordering::Relaxed) {
                     match git
                         .fetch(
                             ShouldPrune::Yes,
+                            // with_complete_error so the failure carries git's
+                            // stderr (e.g. "could not read Username", "HTTP 401")
+                            // and we can tell an auth failure from a network blip.
                             Opts::default()
                                 .with_skip_notify_frontend()
-                                .with_skip_interactive_auth(),
+                                .with_skip_interactive_auth()
+                                .with_complete_error(),
                         )
                         .await
                     {
                         Ok(_) => {}
                         Err(e) => {
-                            warn!("Error fetching: {:?}", e);
+                            let msg = e.to_string();
+                            warn!("Error fetching: {}", msg);
+                            // A stomped/erased credential surfaces here. Ask the
+                            // app to repopulate it from the stored PAT so git
+                            // recovers on the next tick instead of at restart.
+                            if is_auth_error(&msg) {
+                                if let Some(tx) = &reauth_tx {
+                                    let _ = tx.try_send(());
+                                }
+                            }
                         }
                     }
                 }
@@ -97,5 +141,35 @@ impl GitMaintenanceRunner {
         tokio::try_join!(fetch_task, maintenance_task)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_auth_error;
+
+    #[test]
+    fn auth_errors_trigger_reseed_but_network_errors_do_not() {
+        // Missing/erased or rejected credential → re-seed.
+        assert!(is_auth_error(
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+        ));
+        assert!(is_auth_error("error: RPC failed; HTTP 401 curl 22"));
+        assert!(is_auth_error(
+            "fatal: Authentication failed for 'https://github.com'"
+        ));
+        assert!(is_auth_error(
+            "fatal: Cannot prompt because user interactivity has been disabled"
+        ));
+
+        // Network / non-auth failures must NOT trigger a re-seed — re-seeding
+        // can't fix them and would just churn the credential store.
+        assert!(!is_auth_error(
+            "fatal: unable to access 'https://github.com/': Could not resolve host: github.com"
+        ));
+        assert!(!is_auth_error(
+            "Git command failed. Check the log for details."
+        ));
+        assert!(!is_auth_error("error: RPC failed; HTTP 500"));
     }
 }

--- a/core/src/clients/git_maintenance_runner.rs
+++ b/core/src/clients/git_maintenance_runner.rs
@@ -57,7 +57,9 @@ impl GitMaintenanceRunner {
                     match git
                         .fetch(
                             ShouldPrune::Yes,
-                            Opts::default().with_skip_notify_frontend(),
+                            Opts::default()
+                                .with_skip_notify_frontend()
+                                .with_skip_interactive_auth(),
                         )
                         .await
                     {

--- a/core/src/types/config.rs
+++ b/core/src/types/config.rs
@@ -121,6 +121,13 @@ pub struct AppConfig {
     #[serde(default, rename = "githubPAT", skip_serializing_if = "Option::is_none")]
     pub github_pat: Option<RedactedString>,
 
+    /// When true (the default), the PAT is also seeded into git's configured
+    /// credential helper so background fetch/pull/push authenticate without an
+    /// interactive login. Off means Friendshipper never touches git's
+    /// credential store and the PAT stays API-only.
+    #[serde(default = "default_true", rename = "seedGitCredentials")]
+    pub seed_git_credentials: bool,
+
     #[serde(default, rename = "engineType")]
     pub engine_type: EngineType,
 
@@ -189,6 +196,10 @@ fn default_playtest_region() -> String {
     AWS_REGION.to_string()
 }
 
+fn default_true() -> bool {
+    true
+}
+
 impl AppConfig {
     pub fn new(app_name: &str) -> Self {
         #[cfg(target_os = "windows")]
@@ -217,6 +228,7 @@ impl AppConfig {
             editor_download_symbols: false,
             open_uproject_after_sync: true,
             github_pat: Default::default(),
+            seed_git_credentials: true,
             engine_type: Default::default(),
             engine_prebuilt_path: engine_prebuilt_path.to_string_lossy().to_string(),
             engine_source_path: Default::default(),
@@ -652,7 +664,17 @@ pub struct UnrealVerSelDiagResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::config::CUSTOM_ENGINE_ASSOCIATION_REGEX;
+    use crate::types::config::{AppConfig, CUSTOM_ENGINE_ASSOCIATION_REGEX};
+
+    // Users upgrading from a build without the toggle have no
+    // `seedGitCredentials` key in their saved config — seeding must stay ON
+    // for them, not silently flip off.
+    #[test]
+    fn seed_git_credentials_defaults_on_when_absent() {
+        let cfg: AppConfig = serde_yaml::from_str("repoPath: foo").expect("parse minimal config");
+        assert!(cfg.seed_git_credentials);
+        assert!(AppConfig::new("test").seed_git_credentials);
+    }
 
     #[test]
     fn test_engine_association_regex() {

--- a/core/src/utils/process.rs
+++ b/core/src/utils/process.rs
@@ -52,6 +52,99 @@ pub async fn run_with_stdin(mut cmd: Command, stdin: Vec<u8>) -> Result<Output> 
     Ok(output)
 }
 
+/// A Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` wrapping one
+/// spawned child: terminating the job — or merely dropping this guard — kills
+/// the child's entire process tree, not just the child. Exists because
+/// `Child::kill` is `TerminateProcess` on the direct child only: git's helpers
+/// (`git-remote-https`, a GCM credential prompt) survive it, keep the
+/// inherited stdout/stderr pipe write ends open, and starve the pipe readers
+/// of EOF. Job membership is inherited by every descendant, so closing the job
+/// takes the stragglers down and the pipes actually close.
+///
+/// Best-effort by design: `assign` returning `None` (already-exited child, job
+/// API failure) must degrade at the call site to a plain kill, never to an
+/// error.
+#[cfg(windows)]
+pub struct ProcessTreeJob {
+    handle: windows::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl ProcessTreeJob {
+    /// Create the job and put `child` — and, transitively, its future
+    /// descendants — in it. Anything the child spawned *before* this call
+    /// lands outside the job; assign immediately after spawn to keep that
+    /// window negligible.
+    pub fn assign(child: &tokio::process::Child) -> Option<Self> {
+        use windows::core::PCWSTR;
+        use windows::Win32::Foundation::HANDLE;
+        use windows::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        // None once the child has been reaped — nothing left to assign.
+        let raw = child.raw_handle()?;
+
+        // Wrapped in Self immediately so an early return below still closes
+        // the job handle via Drop.
+        let job = match unsafe { CreateJobObjectW(None, PCWSTR::null()) } {
+            Ok(handle) => Self { handle },
+            Err(e) => {
+                warn!("CreateJobObjectW failed: {e}");
+                return None;
+            }
+        };
+
+        let info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+            BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
+                LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        if let Err(e) = unsafe {
+            SetInformationJobObject(
+                job.handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&info).cast(),
+                std::mem::size_of_val(&info) as u32,
+            )
+        } {
+            warn!("SetInformationJobObject failed: {e}");
+            return None;
+        }
+
+        if let Err(e) = unsafe { AssignProcessToJobObject(job.handle, HANDLE(raw as isize)) } {
+            // E.g. a sandbox/launcher job that forbids nesting
+            // (pre-Windows-8 semantics).
+            warn!("AssignProcessToJobObject failed: {e}");
+            return None;
+        }
+
+        Some(job)
+    }
+
+    /// Kill every process still in the job, immediately.
+    pub fn terminate(&self) {
+        if let Err(e) =
+            unsafe { windows::Win32::System::JobObjects::TerminateJobObject(self.handle, 1) }
+        {
+            warn!("TerminateJobObject failed: {e}");
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessTreeJob {
+    fn drop(&mut self) {
+        // KILL_ON_JOB_CLOSE fires when the last handle closes, so plain drop
+        // also kills anything still alive in the job.
+        let _ = unsafe { windows::Win32::Foundation::CloseHandle(self.handle) };
+    }
+}
+
 pub fn wait_for_port(port: u16) -> Result<()> {
     let result = retry_with_index(
         Fixed::from_millis(1000).take(STARTUP_RETRY_ATTEMPTS),
@@ -194,6 +287,42 @@ mod tests {
 
         let out = run_with_stdin(cmd, Vec::new()).await.expect("spawned");
         assert!(!out.status.success());
+    }
+
+    // ProcessTreeJob must kill the WHOLE tree: cmd spawns ping as a grandchild
+    // sharing our stdout pipe; after terminate(), read_to_end must hit EOF
+    // promptly, which can only happen once every process holding the pipe's
+    // write end (cmd AND ping) is dead. This mirrors the production hazard:
+    // git.exe's orphaned children keeping the pipes open past kill() and
+    // wedging the reader joins behind the git process lock.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn process_tree_job_terminate_kills_grandchildren_and_closes_pipes() {
+        use tokio::io::AsyncReadExt;
+
+        let mut cmd = Command::new("cmd");
+        // ~30s of pings; the test only finishes quickly if they're killed.
+        cmd.args(["/c", "ping -n 30 127.0.0.1"]);
+        cmd.stdout(Stdio::piped());
+        let mut child = cmd.spawn().expect("spawn cmd");
+        let mut stdout = child.stdout.take().expect("stdout piped");
+        let job = ProcessTreeJob::assign(&child).expect("assign job");
+
+        // Give cmd a beat to spawn ping, so the grandchild exists (and holds
+        // the pipe) before the kill.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        job.terminate();
+
+        let mut buf = Vec::new();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stdout.read_to_end(&mut buf),
+        )
+        .await
+        .expect("pipe never reached EOF — a process in the job survived terminate()")
+        .expect("read stdout");
+        let _ = child.wait().await;
     }
 
     #[cfg(unix)]

--- a/friendshipper/src-tauri/src/config/router.rs
+++ b/friendshipper/src-tauri/src/config/router.rs
@@ -262,22 +262,6 @@ where
                 // store pat in keyring
                 let entry = keyring::Entry::new(APP_NAME, KEYRING_USER)?;
                 entry.set_password(&pat.to_string())?;
-
-                // Seed git's credential helper with the PAT so network git
-                // operations (fetch/pull/push/lfs) authenticate via this token
-                // instead of the helper popping an interactive login. The
-                // GraphQL client was just created above, so github_username is
-                // populated. Best-effort: a failure here must not block saving
-                // config — it just means git auth falls back to its prior
-                // behavior.
-                let username = state.github_username();
-                if let Err(e) = state
-                    .git()
-                    .store_credential("github.com", &username, &pat.to_string())
-                    .await
-                {
-                    warn!("Failed to seed git credential from PAT: {e}");
-                }
             }
             None => {
                 // Only worry about this if we don't already have a Github Client
@@ -291,10 +275,41 @@ where
         }
     }
 
+    // Captured before `payload` is moved into state below; the credential
+    // work runs after that write on purpose (see comment there).
+    let seed_git_credentials = payload.seed_git_credentials;
+    let pat_to_seed = payload.github_pat.clone();
+
     {
         let mut lock = state.app_config.write();
         *lock = payload;
         lock.initialized = true;
+    }
+
+    // Git credential seeding runs AFTER the state write so `state.git()`
+    // targets the repo the user just selected, not the previous one — the
+    // username pin is a persistent .git/config write, and landing it in an
+    // abandoned repo both misconfigures that repo and leaves the new one
+    // unpinned. Best-effort: a failure must not block saving config. Gated on
+    // the preference being saved right now, so unchecking the box stops
+    // credential writes with this save; disabling also removes our username
+    // pin (restoring any value the user had before we overwrote it), handing
+    // git auth fully back to them.
+    if !state.app_config.read().repo_path.is_empty() {
+        if seed_git_credentials {
+            if let Some(pat) = pat_to_seed {
+                let username = state.github_username();
+                if let Err(e) = state
+                    .git()
+                    .store_credential("github.com", &username, &pat.to_string())
+                    .await
+                {
+                    warn!("Failed to seed git credential from PAT: {e}");
+                }
+            }
+        } else if let Err(e) = state.git().remove_credential_pin("github.com").await {
+            warn!("Failed to remove git credential username pin: {e}");
+        }
     }
 
     save_config_to_file(state, "Preferences successfully saved!")?;

--- a/friendshipper/src-tauri/src/config/router.rs
+++ b/friendshipper/src-tauri/src/config/router.rs
@@ -5,7 +5,7 @@ use axum::extract::Query;
 use axum::{extract::State, routing::get, Json, Router};
 use ethos_core::AWSClient;
 use serde::Deserialize;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use ethos_core::clients::github::GraphQLClient;
 use ethos_core::clients::kube::ensure_kube_client;
@@ -262,6 +262,22 @@ where
                 // store pat in keyring
                 let entry = keyring::Entry::new(APP_NAME, KEYRING_USER)?;
                 entry.set_password(&pat.to_string())?;
+
+                // Seed git's credential helper with the PAT so network git
+                // operations (fetch/pull/push/lfs) authenticate via this token
+                // instead of the helper popping an interactive login. The
+                // GraphQL client was just created above, so github_username is
+                // populated. Best-effort: a failure here must not block saving
+                // config — it just means git auth falls back to its prior
+                // behavior.
+                let username = state.github_username();
+                if let Err(e) = state
+                    .git()
+                    .store_credential("github.com", &username, &pat.to_string())
+                    .await
+                {
+                    warn!("Failed to seed git credential from PAT: {e}");
+                }
             }
             None => {
                 // Only worry about this if we don't already have a Github Client

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -134,7 +134,7 @@ async fn filter_to_textlike_paths(
     // app git process (which is what stomps the GCM credential / collides on
     // .git). Scoped so the guard releases the instant the process exits.
     let output = {
-        let _git_lock = git::acquire_git_process_lock().await;
+        let _git_lock = git::acquire_git_process_lock("git check-attr (submit)").await;
         ethos_core::utils::process::run_with_stdin(cmd, input).await?
     };
     if !output.status.success() {
@@ -487,7 +487,8 @@ async fn run_git_with_index(
     // Serialize against every other app git process; this writes loose objects
     // via the temp index, exactly like core's locked `run_with_index_file`.
     // Held across the spawn+wait; released on return.
-    let _git_lock = git::acquire_git_process_lock().await;
+    let _git_lock =
+        git::acquire_git_process_lock(&format!("git {} (submit index)", args.join(" "))).await;
     Ok(cmd.output().await?)
 }
 

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -129,7 +129,14 @@ async fn filter_to_textlike_paths(
     // `run_with_stdin` feeds the (potentially >1 MB) path list to check-attr
     // from a dedicated task while draining stdout, so a large submit can't
     // deadlock on the pipe buffers. See its docs for the gory details.
-    let output = ethos_core::utils::process::run_with_stdin(cmd, input).await?;
+    //
+    // Hold GIT_PROCESS_LOCK across the spawn+wait so this never overlaps another
+    // app git process (which is what stomps the GCM credential / collides on
+    // .git). Scoped so the guard releases the instant the process exits.
+    let output = {
+        let _git_lock = git::acquire_git_process_lock().await;
+        ethos_core::utils::process::run_with_stdin(cmd, input).await?
+    };
     if !output.status.success() {
         bail!(
             "git check-attr failed: {}",
@@ -477,6 +484,10 @@ async fn run_git_with_index(
     }
     #[cfg(windows)]
     cmd.creation_flags(crate::repo::CREATE_NO_WINDOW);
+    // Serialize against every other app git process; this writes loose objects
+    // via the temp index, exactly like core's locked `run_with_index_file`.
+    // Held across the spawn+wait; released on return.
+    let _git_lock = git::acquire_git_process_lock().await;
     Ok(cmd.output().await?)
 }
 

--- a/friendshipper/src-tauri/src/repo/operations/status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/status.rs
@@ -107,7 +107,6 @@ where
         let status_future = self.git_client.status(vec![]);
 
         let (locks, status_output) = futures::join!(locks_future, status_future);
-        let locks = locks?;
         let status_output = status_output?;
 
         let status_lines = status_output.lines().collect::<Vec<_>>();
@@ -178,8 +177,25 @@ where
 
         {
             status.lock_user.clone_from(&self.github_username);
-            status.locks_ours = locks.ours;
-            status.locks_theirs = locks.theirs;
+            match locks {
+                Ok(locks) => {
+                    status.locks_ours = locks.ours;
+                    status.locks_theirs = locks.theirs;
+                }
+                Err(e) => {
+                    // verify_locks runs non-interactively (it must not pop a
+                    // credential prompt from a background status refresh), so a
+                    // stale credential surfaces here as an error rather than a
+                    // GCM window. Preserve the last-known lock state instead of
+                    // failing the entire status refresh; the next user-initiated
+                    // pull/push re-authenticates and the following refresh
+                    // repopulates locks.
+                    warn!("verify_locks failed; preserving previous lock state: {e}");
+                    let current_status = self.repo_status.read();
+                    status.locks_ours.clone_from(&current_status.locks_ours);
+                    status.locks_theirs.clone_from(&current_status.locks_theirs);
+                }
+            }
 
             info!(
                 %status.lock_user,
@@ -394,11 +410,16 @@ where
     }
 
     async fn get_modified_upstream(&self, branch: &str) -> Result<Vec<String>, anyhow::Error> {
+        // This `ls-remote` runs as part of the ambient status refresh, so it
+        // must not pop an interactive credential prompt. Run it
+        // non-interactively: a stale credential makes this fail quietly,
+        // `upstream_exists` becomes false, and we skip the upstream-modified
+        // check until the next user-initiated sync re-authenticates.
         let upstream_exists = self
             .git_client
             .run_and_collect_output(
                 &["ls-remote", "--exit-code", "--heads", "origin", branch],
-                git::Opts::default(),
+                git::Opts::default().with_skip_interactive_auth(),
             )
             .await
             .is_ok();

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -401,9 +401,49 @@ impl Server {
                 }
             }
 
+            // Auto-repopulate the git credential if a background fetch later
+            // hits an auth error (a stomped or erased credential — e.g. after a
+            // transient 401, or a second process racing the credential store).
+            // The maintenance runner signals on this channel; we re-seed from
+            // the stored PAT so git recovers on the next fetch tick instead of
+            // only at restart. Capacity 1 collapses bursts into one re-seed.
+            let (reauth_tx, mut reauth_rx) = tokio::sync::mpsc::channel::<()>(1);
+            let reseed_state = shared_state.clone();
+            tokio::spawn(async move {
+                // Cooldown so that if the PAT itself is rejected (e.g. a lapsed
+                // SSO authorization), the every-tick failures don't churn the
+                // credential store with re-seeds that cannot help.
+                let cooldown = Duration::from_secs(120);
+                let mut last_reseed: Option<std::time::Instant> = None;
+                while reauth_rx.recv().await.is_some() {
+                    if let Some(t) = last_reseed {
+                        if t.elapsed() < cooldown {
+                            continue;
+                        }
+                    }
+                    let pat = match keyring::Entry::new(APP_NAME, KEYRING_USER)
+                        .and_then(|e| e.get_password())
+                    {
+                        Ok(p) if !p.is_empty() => p,
+                        _ => continue,
+                    };
+                    let username = reseed_state.github_username();
+                    info!("Background fetch hit an auth error; repopulating git credential from stored PAT");
+                    if let Err(e) = reseed_state
+                        .git()
+                        .store_credential("github.com", &username, &pat)
+                        .await
+                    {
+                        warn!("Failed to repopulate git credential after auth error: {e}");
+                    }
+                    last_reseed = Some(std::time::Instant::now());
+                }
+            });
+
             let maintenance_runner =
                 GitMaintenanceRunner::new(repo_path, pause_background_tasks.clone(), tx)
-                    .with_fetch_interval(Duration::from_secs(30));
+                    .with_fetch_interval(Duration::from_secs(30))
+                    .with_reauth_notifier(reauth_tx);
             tokio::spawn(async move {
                 match maintenance_runner.run().await {
                     Ok(_) => {}

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -386,7 +386,19 @@ impl Server {
             // interactive login — and so a credential the helper erased after a
             // prior 401 is restored on launch. Awaited inline so it's in place
             // before the maintenance runner's first fetch. Best-effort.
-            if let Ok(entry) = keyring::Entry::new(APP_NAME, KEYRING_USER) {
+            // Gated on the user preference: with seeding off, Friendshipper
+            // never touches git's credential store. It does remove its own
+            // username pin (a persistent .git/config write from an earlier
+            // seed) if one is still present — restoring whatever value the
+            // user had — so opting out really does hand git auth back to them
+            // even if the disable happened by editing the config file or via a
+            // save that never reached the unpin. No-op when we never pinned.
+            if !shared_state.app_config.read().seed_git_credentials {
+                info!("Git credential seeding is disabled in preferences; leaving git auth alone");
+                if let Err(e) = shared_state.git().remove_credential_pin("github.com").await {
+                    warn!("Failed to remove leftover git credential username pin: {e}");
+                }
+            } else if let Ok(entry) = keyring::Entry::new(APP_NAME, KEYRING_USER) {
                 if let Ok(pat) = entry.get_password() {
                     if !pat.is_empty() {
                         let username = shared_state.github_username();
@@ -416,6 +428,11 @@ impl Server {
                 let cooldown = Duration::from_secs(120);
                 let mut last_reseed: Option<std::time::Instant> = None;
                 while reauth_rx.recv().await.is_some() {
+                    // Re-read the preference each signal so turning seeding
+                    // off in Preferences takes effect without a restart.
+                    if !reseed_state.app_config.read().seed_git_credentials {
+                        continue;
+                    }
                     if let Some(t) = last_reseed {
                         if t.elapsed() < cooldown {
                             continue;

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -380,6 +380,27 @@ impl Server {
         // fetch` reading the same .git/config — on Windows that surfaces as
         // "unable to access '.git/config': Permission denied".
         if !repo_path.is_empty() {
+            // Seed git's credential helper from the stored PAT before any
+            // background git runs, so fetch/maintenance/status authenticate via
+            // the (ideally non-expiring) token instead of popping an
+            // interactive login — and so a credential the helper erased after a
+            // prior 401 is restored on launch. Awaited inline so it's in place
+            // before the maintenance runner's first fetch. Best-effort.
+            if let Ok(entry) = keyring::Entry::new(APP_NAME, KEYRING_USER) {
+                if let Ok(pat) = entry.get_password() {
+                    if !pat.is_empty() {
+                        let username = shared_state.github_username();
+                        if let Err(e) = shared_state
+                            .git()
+                            .store_credential("github.com", &username, &pat)
+                            .await
+                        {
+                            warn!("Failed to seed git credential from PAT at startup: {e}");
+                        }
+                    }
+                }
+            }
+
             let maintenance_runner =
                 GitMaintenanceRunner::new(repo_path, pause_background_tasks.clone(), tx)
                     .with_fetch_interval(Duration::from_secs(30));

--- a/friendshipper/src-tauri/src/server.rs
+++ b/friendshipper/src-tauri/src/server.rs
@@ -382,7 +382,7 @@ impl Server {
         if !repo_path.is_empty() {
             let maintenance_runner =
                 GitMaintenanceRunner::new(repo_path, pause_background_tasks.clone(), tx)
-                    .with_fetch_interval(Duration::from_secs(5));
+                    .with_fetch_interval(Duration::from_secs(30));
             tokio::spawn(async move {
                 match maintenance_runner.run().await {
                     Ok(_) => {}

--- a/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
+++ b/friendshipper/src/lib/components/preferences/PreferencesModal.svelte
@@ -762,6 +762,20 @@
 					<Tooltip class="text-sm" placement="bottom">
 						Copy and paste your GitHub Personal Access Token (PAT) here.
 					</Tooltip>
+
+					<div class="flex flex-row gap-2 pt-1">
+						<Checkbox
+							bind:checked={localAppConfig.seedGitCredentials}
+							class="w-8 h-8 text-4xl mb-2 bg-secondary-800 dark:bg-space-950"
+						/>
+						<Label class="text-white">Use PAT for git sign-in</Label>
+					</div>
+					<Tooltip class="text-sm" placement="bottom">
+						Friendshipper keeps git's stored credential for github.com in sync with this PAT so
+						background syncs never pop a login window. Disable if you manage git credentials
+						yourself: Friendshipper removes its username pin from the project's git config and stops
+						touching git credentials entirely.
+					</Tooltip>
 				</div>
 			</div>
 		</div>

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -72,6 +72,7 @@ export interface AppConfig {
 	primaryBranch?: string;
 	contentBranch?: string;
 	githubPAT: string;
+	seedGitCredentials: boolean;
 	engineType: string;
 	enginePrebuiltPath: string;
 	engineSourcePath: string;


### PR DESCRIPTION
## Summary

Friendshipper spawns many `git` subprocesses against a single repo and credential store — foreground ops, a background fetch/maintenance loop, the file-watcher status refresh, and direct handlers. Several ran concurrently, which stomped the Git Credential Manager (GCM) credential (spurious "Connect to GitHub" / re-auth popups unrelated to any user action) and risked `.git` index/ref/packfile collisions.

This branch serializes all app git, keeps background/ambient git non-interactive, and routes the in-app PAT into git's own credential helper so auth is stable and self-healing.

## What this delivers

- **All git subprocesses are serialized.** A process-wide lock is held for the lifetime of every `git` child, acquired at the single command chokepoint plus the few raw-spawn sites (`head_commit`, temp-index ops, `configure_global`, submit's `check-attr`). The app never has two git processes in flight at once. The lock is non-reentrant and ordered consistently with the existing fetch-coalescing lock.

- **A stalled git process can't wedge the app.** An idle (no-output) timeout kills a process that has gone silent (stuck prompt, dead connection) so the lock is released — but never kills a healthy long-running op (clone / fetch / LFS pull) that's still streaming progress.

- **Background and ambient git never prompt.** The fetch + maintenance loop and the status-refresh network calls (`git lfs locks --verify`, upstream `ls-remote`) run with interactive auth disabled, so a stale credential fails quietly instead of popping a login window; re-auth happens only on a deliberate user pull/push. A lock-verify failure preserves the last-known lock state instead of failing the whole status refresh.

- **The PAT actually feeds git.** The stored PAT (previously used only for the GitHub HTTP API) is written into git's credential helper via `git credential approve` over stdin, never on the command line or in logs. Any stale host-level credential is evicted first so the fresh PAT resolves for a bare-host fetch. Seeded at startup and on PAT save.

- **Auth is self-healing and observable.** A background fetch that fails with an auth error auto-repopulates the credential from the stored PAT (recovers within a fetch tick, no restart), with a cooldown so a genuinely-rejected token doesn't churn. Lock contention is logged with the operation that's holding the lock.

## Scope

`core/src/clients/git.rs`, `core/src/clients/git_maintenance_runner.rs`; `friendshipper` `status.rs`, `server.rs`, `config/router.rs`, `gh/submit.rs`. Includes #612.

## Testing

- `cargo clippy --all-targets` / `cargo fmt --check` clean; workspace builds across all three crates.
- Unit tests: credential seed/evict round-trip via `git credential fill` (isolated from the real helper), `is_auth_error` auth-vs-network classification, and the existing snapshot/restore suite (which exercises the multi-acquire lock path).
- Validated against live Friendshipper logs: background fetches and LFS-lock checks succeed with no popups, and a captured 401 recovered via automatic re-seed.

## Reviewer notes (judgment calls)

- Startup seeding **unconditionally** evicts and replaces git's `github.com` credential from the app PAT — intended under a PAT-first policy, but a stale app PAT could regress a working credential.
- The idle-timeout backstop covers the command chokepoint; the local raw-spawn sites hold the lock without it (all are local/fast).
- `GIT_PROCESS_LOCK` is process-local — two overlapping Friendshipper instances could still race the credential store; mitigated by the startup process check and auto-repopulate, not fully prevented.
- Cannot fix a genuinely invalid PAT (e.g. lapsed SSO authorization); re-seeding the same rejected token can't help, but the logs make that case identifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
