### PR TITLE
fix(core): linux dupe startup check and longtail version

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,11 +60,16 @@ pub const BIN_SUFFIX: &str = "friendshipper-linux-amd64";
 pub const BIN_SUFFIX: &str = "friendshipper-darwin-amd64";
 
 // Longtail download info
+#[cfg(target_os = "windows")]
+const LONGTAIL_VERSION: &str = "v0.4.2";
+#[cfg(target_os = "linux")]
+const LONGTAIL_VERSION: &str = "v0.4.5";
+#[cfg(target_os = "macos")]
 const LONGTAIL_VERSION: &str = "v0.4.2";
 #[cfg(target_os = "windows")]
 const LONGTAIL_SHA256: &str = "2cb9396d4a09f7083dc5909296944c155415eb4e3c7cbb79dd7d835a2db46e25";
 #[cfg(target_os = "linux")]
-const LONGTAIL_SHA256: &str = "ea702f4236b7d7edb0619101a1ead350437d5d43ad138ef90ed925303fd2d4fd";
+const LONGTAIL_SHA256: &str = "91094c3c28f48b66014f0f5d2679bf6fa1880ca6ce971f861f011c31251401f3";
 #[cfg(target_os = "macos")]
 const LONGTAIL_SHA256: &str = "cf71bb53f1b2819e5aebfcd1b7cbfbf24e88b4bc8ecdf1147bac6fdc4e56d92a";
 const LONGTAIL_DL_PREFIX: &str = "https://github.com/DanEngelbrecht/golongtail/releases/download";

--- a/core/src/utils/process.rs
+++ b/core/src/utils/process.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
 use retry::delay::Fixed;
 use retry::{retry_with_index, OperationResult};
+use std::collections::HashSet;
 use std::net::TcpListener;
+use std::path::Path;
 use std::process::{Output, Stdio};
 use sysinfo::Pid;
 use tokio::io::AsyncWriteExt;
@@ -77,6 +79,37 @@ pub fn wait_for_port(port: u16) -> Result<()> {
     }
 }
 
+/// PIDs from `pid` up to the root of the process tree.
+///
+/// Excludes our own ancestry from `check_for_process`'s kill scan — e.g. the
+/// old instance that spawns a new one during `restart`/relaunch and is still
+/// exiting when the new one starts up.
+fn ancestor_pids(system: &sysinfo::System, pid: u32) -> HashSet<u32> {
+    let mut ancestors = HashSet::new();
+    let mut current = Pid::from_u32(pid);
+    while let Some(parent) = system.process(current).and_then(sysinfo::Process::parent) {
+        if !ancestors.insert(parent.as_u32()) {
+            break; // cycle guard; shouldn't happen on a real process tree
+        }
+        current = parent;
+    }
+    ancestors
+}
+
+/// True if `candidate_exe` is the `.AppImage` file we ourselves were
+/// launched from (per `$APPIMAGE`).
+///
+/// The AppImage runtime double-forks its FUSE-mount server, which gets
+/// reparented away from us (not our ancestor) and re-execs the outer
+/// `.AppImage` file — unprotected, `check_for_process`'s by-name scan kills
+/// it and tears the mount down under us.
+fn is_own_appimage_runtime(candidate_exe: Option<&Path>, appimage_env: Option<&str>) -> bool {
+    match (candidate_exe, appimage_env) {
+        (Some(exe), Some(appimage)) => exe == Path::new(appimage),
+        _ => false,
+    }
+}
+
 pub fn check_for_process(name: &str, port: u16) -> Result<()> {
     // add bin suffix
 
@@ -86,17 +119,29 @@ pub fn check_for_process(name: &str, port: u16) -> Result<()> {
         sysinfo::ProcessRefreshKind::new().with_exe(sysinfo::UpdateKind::OnlyIfNotSet);
 
     let my_pid: u32 = std::process::id();
+    let appimage_env = std::env::var("APPIMAGE").ok();
     let result = retry_with_index(
         Fixed::from_millis(1000).take(STARTUP_RETRY_ATTEMPTS),
         |attempt| {
             system.refresh_processes_specifics(refresh_kind);
+            let excluded_pids = ancestor_pids(&system, my_pid);
 
             for (pid, process) in system.processes() {
                 let proc_name = process.name().to_lowercase();
                 let proc_path_dev = process
                     .exe()
                     .map(|p| p.to_string_lossy().contains("target"));
+                // `thread_kind()` is Some(_) for the thread entries sysinfo
+                // lists alongside real processes on Linux (via
+                // `/proc/<pid>/task`) — every thread of every process shows
+                // up here with the owning process's own name. Without this,
+                // the scan matches one of our own threads as "another
+                // instance" and kills it, which is process-directed and
+                // takes the whole thing down.
                 if pid.as_u32() != my_pid
+                    && process.thread_kind().is_none()
+                    && !excluded_pids.contains(&pid.as_u32())
+                    && !is_own_appimage_runtime(process.exe(), appimage_env.as_deref())
                     && proc_name.contains(&name.to_lowercase())
                     && !proc_path_dev.is_some_and(|p| p)
                 {
@@ -116,7 +161,7 @@ pub fn check_for_process(name: &str, port: u16) -> Result<()> {
             match listeners::get_processes_by_port(port) {
                 Ok(listeners) => {
                     for listener in listeners {
-                        if listener.pid != my_pid {
+                        if listener.pid != my_pid && !excluded_pids.contains(&listener.pid) {
                             if let Some(process) = system.process(Pid::from_u32(listener.pid)) {
                                 warn!(
                                     "Found existing process {} on port {} but couldn't reach its API. Attempting to kill it.",
@@ -161,6 +206,117 @@ pub fn check_for_process(name: &str, port: u16) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ancestor_pids_includes_our_own_parent() {
+        // We don't need an actual AppImage to exercise this: spawning any
+        // child and walking up from its PID should land on ours, one hop in.
+        #[cfg(windows)]
+        let mut child = std::process::Command::new("cmd")
+            .args(["/c", "timeout", "/t", "5"])
+            .spawn()
+            .expect("spawn child");
+        #[cfg(unix)]
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .expect("spawn child");
+
+        let mut system = sysinfo::System::new();
+        let refresh_kind =
+            sysinfo::ProcessRefreshKind::new().with_exe(sysinfo::UpdateKind::OnlyIfNotSet);
+        system.refresh_processes_specifics(refresh_kind);
+
+        let my_pid = std::process::id();
+        let ancestors = ancestor_pids(&system, child.id());
+        assert!(
+            ancestors.contains(&my_pid),
+            "expected {ancestors:?} to contain our pid {my_pid}"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn is_own_appimage_runtime_matches_appimage_env_exactly() {
+        let appimage = "/home/user/Friendshipper.AppImage";
+
+        // The AppImage runtime process itself: exe is the outer file.
+        assert!(is_own_appimage_runtime(
+            Some(Path::new(appimage)),
+            Some(appimage)
+        ));
+
+        // Our own payload runs from inside the FUSE mount, not the outer
+        // file — must not match, or we'd exclude every duplicate instance's
+        // payload too.
+        assert!(!is_own_appimage_runtime(
+            Some(Path::new("/tmp/.mount_abc123/usr/bin/friendshipper")),
+            Some(appimage)
+        ));
+
+        // Not running under AppImage at all.
+        assert!(!is_own_appimage_runtime(Some(Path::new(appimage)), None));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn own_threads_are_never_mistaken_for_other_processes() {
+        // The real-world failure this guards against: on Linux, sysinfo
+        // lists every thread of every process as its own entry in
+        // `system.processes()` (via `/proc/<pid>/task`), with `pid` = TID.
+        // Without filtering on `thread_kind()`, `check_for_process`'s
+        // by-name scan matched its own threads as "another instance" and
+        // killed itself outright — confirmed against a packaged build, not
+        // just in theory.
+        //
+        // We identify our own threads by TID (read straight from
+        // `/proc/<pid>/task`) rather than by name: the test harness renames
+        // each test's own worker thread (visible in a panic as `thread
+        // '<test name>' panicked`), and threads we spawn inherit that
+        // renamed comm, not the process's — a harness quirk, not something
+        // `check_for_process` relies on in production, where nothing
+        // renames the main thread.
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                std::thread::spawn(|| std::thread::sleep(std::time::Duration::from_millis(300)))
+            })
+            .collect();
+        // Give the kernel a moment to expose the new tasks under /proc.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let my_pid = std::process::id();
+        let task_ids: std::collections::HashSet<u32> =
+            std::fs::read_dir(format!("/proc/{my_pid}/task"))
+                .expect("our own /proc/<pid>/task should be readable")
+                .filter_map(|entry| entry.ok()?.file_name().to_str()?.parse().ok())
+                .filter(|tid| *tid != my_pid)
+                .collect();
+        assert!(
+            !task_ids.is_empty(),
+            "expected our own spawned threads to show up under /proc/{my_pid}/task"
+        );
+
+        let mut system = sysinfo::System::new();
+        let refresh_kind =
+            sysinfo::ProcessRefreshKind::new().with_exe(sysinfo::UpdateKind::OnlyIfNotSet);
+        system.refresh_processes_specifics(refresh_kind);
+
+        for tid in &task_ids {
+            let thread_kind = system
+                .process(Pid::from_u32(*tid))
+                .and_then(|p| p.thread_kind());
+            assert!(
+                thread_kind.is_some(),
+                "TID {tid} is one of our own threads; sysinfo should report it as a thread, not a process"
+            );
+        }
+
+        for handle in handles {
+            let _ = handle.join();
+        }
+    }
 
     #[tokio::test]
     async fn run_with_stdin_feeds_input_and_captures_output() {


### PR DESCRIPTION
- Longtail version bump from a Linux bug in version 0.4.2 causing ranges of null bytes in downloaded files. No reason to bump other platforms.

- Couple of related issues in check_for_process that identifies and kills too many processes. The only behavior change expected on Windows is during an upgrade the old process is no longer killed, but should exit cleanly. We now check that we aren't killing parent processes of the current process, the AppImage runtime env, or threads of the current process.

If `check_for_process` causes issues, reworking this behavior to use `tauri-plugin-single-instance` is a viable next step, but attempted a targeted fix first.