### PR TITLE
fix(core): remove timing race in own-thread test

### DIFF
--- a/core/src/utils/process.rs
+++ b/core/src/utils/process.rs
@@ -278,9 +278,19 @@ mod tests {
         // renamed comm, not the process's — a harness quirk, not something
         // `check_for_process` relies on in production, where nothing
         // renames the main thread.
+        // Threads park on `stop` rather than sleeping a fixed duration: a
+        // fixed sleep raced sysinfo's refresh on loaded CI runners (a slow
+        // enough refresh could see the thread already exited), so pin their
+        // lifetime to the test's own instead of guessing a duration.
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let handles: Vec<_> = (0..8)
             .map(|_| {
-                std::thread::spawn(|| std::thread::sleep(std::time::Duration::from_millis(300)))
+                let stop = std::sync::Arc::clone(&stop);
+                std::thread::spawn(move || {
+                    while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                })
             })
             .collect();
         // Give the kernel a moment to expose the new tasks under /proc.
@@ -313,6 +323,7 @@ mod tests {
             );
         }
 
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
         for handle in handles {
             let _ = handle.join();
         }


### PR DESCRIPTION
## Summary
- CI failed on `main` (run 29267827924) in `own_threads_are_never_mistaken_for_other_processes`, added in #614, with `TID ... is one of our own threads; sysinfo should report it as a thread, not a process`.
- The test spawned threads that slept a fixed 300ms, then asserted sysinfo still saw them as threads. Under CI load, a slow enough `refresh_processes_specifics` call could run after the thread had already exited, failing the assertion — a timing race in the test, not a regression in `check_for_process` itself (the other two tests from #614 passed in that same run).
- Threads now park on an `AtomicBool` stop flag instead of a fixed sleep, so their lifetime is tied to the test's own control flow rather than a guessed duration. Ran the test 5x locally with no failures, plus the full `ethos-core` suite, clippy, and fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)