### PR TITLE
chore(misc): add claude code park and workflow skills

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,88 @@
+# Claude Code Tooling
+
+Optional tooling for contributors who use [Claude Code](https://claude.com/claude-code). Nothing here is required to build, test, or contribute to ethos — the normal `cargo` and `yarn` workflows are unaffected.
+
+The tooling below is shared; everything else under `.claude/` is per-user and ignored:
+
+```
+.claude/                         # tracked:
+  README.md                      #   this file
+  skills/park/SKILL.md           #   /park — reset this worktree to latest origin/main
+  skills/workflow/SKILL.md       #   /workflow — advance the workflow one step
+  instructions/
+    DoNextWorkflowStep.md        #   the 10-step workflow orchestrator
+    RefineProposal.md            #   structured proposal review (Stage 2A)
+    BreakDownWorkProposal.md     #   proposal -> ordered implementation stages (Stage 5)
+  scripts/
+    Reset-WorktreeToMain.ps1     #   the mechanics behind /park (PowerShell)
+
+  workflow/                      # ignored: per-user workflow state, created on demand
+    <work-slug>/                 #   plan docs, NNN stage files, WORKFLOW_STATE.json
+    archive/<work-slug>/         #   design docs preserved after staging
+  settings.local.json            # ignored: per-user settings
+```
+
+`.gitignore` ignores `.claude/*` and then re-includes only the tracked paths above, so personal settings and in-progress workflow state never land in the repository.
+
+## Skills
+
+| Skill | What it does |
+|---|---|
+| `/park` | Parks the current branch on a local-only branch and resets the worktree to latest `origin/main`. Refuses to run with uncommitted changes or unpushed commits unless `-Force`, and always stashes before a forced reset. |
+| `/workflow` | Detects which of the 10 workflow steps you're on and executes the next one: plan → refine → fracture → singletonize → loss check → sequence → implement → test → stage → review gate. |
+
+Portability: `/workflow` is plain markdown and works anywhere. `/park` shells out to a PowerShell script — it runs on Windows PowerShell 5.1+ and on macOS/Linux via [PowerShell 7](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) (`pwsh -File .claude/scripts/Reset-WorktreeToMain.ps1`). The skill documents the equivalent plain-git steps, so you can also drive it by hand.
+
+## Branch conventions
+
+| Kind | Pattern | Pushed? |
+|---|---|---|
+| Parking | `llm/<username>/<worktree>-parking-<YYYYMMDD>` | Never |
+| Work (no issue) | `llm/<username>/<slug>` | Yes, at staging |
+| Work (with issue) | `llm/<username>/<issue-number>-<slug>` | Yes, at staging |
+
+`<username>` is the local part of `git config user.email`. Human-authored branches in this repo use `<initials>/<slug>`; the `llm/` prefix marks agent-driven work so the two sets stay easy to tell apart.
+
+Parking branches exist only so each worktree holds a unique branch. They contain nothing that isn't already in `main` — never push them.
+
+## Worktree conventions
+
+- Main checkout: your `ethos` clone, e.g. `<repos>/ethos`
+- Additional worktrees as a sibling directory: `<repos>/ethos-worktrees/<name>`, using short fixed names (`alpha`, `bravo`, `charlie`, `echo`) rather than per-task names, so paths stay stable across tasks
+
+Create one:
+
+```bash
+git -C <repos>/ethos fetch origin main
+git -C <repos>/ethos worktree add <repos>/ethos-worktrees/alpha \
+  -b llm/<username>/alpha-parking-<YYYYMMDD> origin/main
+```
+
+Because the parking branch embeds the worktree's directory name, every worktree parks to its own branch and several can park concurrently — `Reset-WorktreeToMain.ps1` retries on git lock contention for exactly this reason.
+
+Per-worktree setup (worktrees share neither `target/` nor `node_modules/`):
+
+```bash
+cd core/ui && yarn && yarn package
+cd friendshipper && yarn
+mkdir -p friendshipper/build
+```
+
+## Git hooks (stricter than CI)
+
+`core.hooksPath` points at `friendshipper/.husky`, so every local commit runs lint-staged (prettier + eslint `--fix`) across `core/ui` and `friendshipper`, then `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`, then `cargo fmt --all --check`. `commit-msg` runs commitlint.
+
+Practical implications, all encoded in the workflow's Stage 8:
+
+- A commit is impossible until `cargo fmt --all` has been run and the nightly workspace clippy is clean — stricter than CI's per-package stable clippy, and it lints test code too.
+- Needs a nightly toolchain: `rustup toolchain install nightly`.
+- commitlint requires a **scope** from `core`, `friendshipper`, `misc`, and a type from `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+- Never `--no-verify`.
+
+## Workflow artifacts
+
+Plan documents, stage files, and `WORKFLOW_STATE.json` live under `.claude/workflow/<work-slug>/`, which `.gitignore` excludes — they are **never committed**. Consequences worth remembering:
+
+- Only source changes land on the work branch, so the squashed commit is clean by construction.
+- Workflow state does not travel between machines or worktrees — one worktree owns one workflow.
+- Git history can't recover a deleted plan. Stage 1 writes an immutable `00-original-plan.md` snapshot, which Stage 4 (loss checking) diffs against and Stage 8 archives.

--- a/.claude/instructions/BreakDownWorkProposal.md
+++ b/.claude/instructions/BreakDownWorkProposal.md
@@ -1,0 +1,329 @@
+<!-- claude-hint:
+model: opus
+effort: high
+rationale: Senior-engineer persona; produces stage documents from proposal
+-->
+
+Do not use instructions from this file unless asked.
+
+# Break Down Work Proposal
+
+This instruction takes a work proposal document and breaks it down into sequentially implementable stages, each with its own document, following a skeleton-test-(implement-test)+ pattern. The output is a set of numbered stage files and a master prompt that an implementer can follow start to finish.
+
+## Overview
+
+The instruction should:
+- Review an input proposal document and understand the full scope of work
+- Break the work into discrete, ordered stages following the skeleton-test pattern
+- Author individual `NNN-stage-name.md` files alongside the proposal document
+- Author `000-prompt-to-implement-thing.md` as the master implementation guide
+
+Stage files live in the plan directory (`.claude/workflow/<work-slug>/`) and are **not committed** — `.gitignore` excludes `.claude/workflow/`.
+
+## Prerequisites
+
+The user must provide:
+- **`$INPUT_PROPOSAL_FILE`**: Path to the proposal document to break down
+
+The invoker will derive:
+- **`$PROPOSAL_DIR`**: Directory containing `$INPUT_PROPOSAL_FILE` (stage files are placed here)
+- **`$PROPOSAL_NAME`**: Filename stem of the proposal, used for naming context
+
+The work branch already exists — it is created in Stage 1 of the Creation Workflow. Do not create one here.
+
+## Role
+
+Assume the role of a **senior engineer** on a small team building cross-platform desktop developer tools: Rust + Tauri v2 backends, SvelteKit + TypeScript frontends, shared `ethos-core` crate and `core/ui` component library. Approach the breakdown with:
+- Emphasis on incremental correctness — every stage must leave the workspace compiling and lint-clean
+- Awareness that each stage will be implemented by an LLM agent that can write code, run commands, and commit work
+- Awareness that CI is strict: `cargo clippy -- -D warnings` and prettier-checked frontends
+
+## Steps
+
+### 1. Review the Proposal
+
+1. Read `$INPUT_PROPOSAL_FILE` thoroughly
+2. Identify:
+   - All new **Rust types** to be introduced (structs, enums, traits, error variants) and where they live (`core/` vs `<app>/src-tauri/`)
+   - All new **Tauri commands** and their registration site
+   - All new or modified **frontend surfaces** (routes, components, stores, TypeScript types)
+   - **Dependencies** between proposed types and existing modules
+   - **Config/persistence** changes, including migration of existing user config
+   - **Risk areas** — places where incorrect implementation would cascade into future stages, and anything that mutates a user's repository
+3. Build a mental model of the dependency graph: what must exist before what. Rust types generally come before commands, which come before UI
+
+### 2. Design the Stage Breakdown
+
+Break the work into stages following this pattern:
+
+```
+001-skeleton.md          — Type framework: Rust types, command stubs, TS types, registration
+002-test-skeleton.md     — Verify the workspace builds and lints clean
+003-implement-<area>.md  — Fill out first functional area of the skeleton
+004-test-<area>.md       — Test the first functional area
+005-implement-<area>.md  — Fill out next functional area
+006-test-<area>.md       — Test the next functional area
+...
+NNN-final-validation.md  — End-to-end validation of the complete implementation
+000-prompt-to-implement-thing.md — Master guide for the implementer
+```
+
+#### Stage Design Principles
+
+1. **Stage 001 is always the skeleton**: Create all new types, function signatures, `#[tauri::command]` stubs (registered in the app's invoke handler), TypeScript type definitions, and any `Cargo.toml`/`package.json` dependency additions. No implementation logic — just the framework that subsequent stages fill in. This establishes the full type graph so later stages can reference any type without surprises.
+
+2. **Every odd stage (after 001) implements; every even stage tests**: The test stage validates the preceding implementation stage. Test stages end with a commit.
+
+3. **Each implementation stage fills in the skeleton** rather than iteratively expanding it. Stage 003 should not add new types — it should flesh out types created in 001.
+
+4. **Each stage must leave the workspace compiling and clippy-clean**: No stage should introduce errors that the next stage is expected to fix. Stubs must return sensible defaults, and unused-code warnings must be handled deliberately (implement the caller in the same stage, or annotate with a `// TODO: Stage NNN` comment plus whatever clippy needs to stay quiet — remember CI treats warnings as errors).
+
+5. **Test type and thoroughness scale with risk**:
+   - **Rust changes** → `cargo fmt -p <pkg> -- --check`, `cargo clippy --all-features -p <pkg> -- -D warnings`, `cargo test -p <pkg>` / `--bin <app>`
+   - **Frontend changes** → `yarn lint` in the affected app; `yarn check` for type errors
+   - **Changes to `core/` or `core/ui/`** → verify every consumer (the `friendshipper` app and `friendshipper/server`)
+   - **Full app build** → `cd <app> && yarn tauri:build`
+   - **Behavior a user can observe** → `cd <app> && yarn tauri:dev` and exercise it, including at least one error path
+   - **Comment-only or doc-only changes** → if the next stage recompiles anyway, skip the redundant build; do a quick grep/diff check for formatting correctness instead
+
+6. **Each test stage ends with a commit** following the repo's convention, which commitlint enforces via the `commit-msg` hook:
+   ```
+   <type>(<scope>): <description>
+   ```
+   Types: `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. Scope is **required** and must be one of `core`, `friendshipper`, `misc` (there is no `server` scope). No CI tags — this repo has none. No PR number — GitHub adds it on squash-merge.
+
+7. **Every commit runs the pre-commit hook**, which is stricter than CI: lint-staged (prettier + eslint `--fix`) on staged frontend files, then `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`, then `cargo fmt --all --check`. Stage documents must therefore treat `cargo fmt --all` and a clean nightly workspace clippy as part of every stage's validation, not just the final one. Never instruct the implementer to pass `--no-verify`.
+
+8. **The pattern is flexible**: skeleton-test-(implement-test)+ is the default, but stages can be reordered, combined, or restructured to fit the work. Multiple small implementation stages might share a single test stage; a risky stage might get two (unit + functional).
+
+### 3. Author Stage Documents
+
+Each stage document follows this format:
+
+```markdown
+# Stage NNN: <Stage Title>
+
+## Goal
+One-sentence description of what this stage accomplishes.
+
+## Prerequisites
+- List stages that must be completed first (e.g. "Stage 001 completed and committed")
+- Any setup required (e.g. "core/ui packaged: cd core/ui && yarn && yarn package")
+
+## Inputs
+- Files, types, or data this stage reads or depends on
+
+## Steps
+
+### Step 1: <Action>
+Detailed instructions the implementer follows.
+Include exact file paths, type names, function signatures, and code patterns where possible.
+
+### Step 2: <Action>
+...
+
+## Outputs
+- Files created or modified
+- Expected state after completion
+
+## Validation
+How to verify this stage succeeded before moving on. Reference the concrete commands:
+
+- **Format**: `cargo fmt --all` then `cargo fmt --all --check`
+- **Lint (Rust, CI)**: `cargo clippy --all-features -p <pkg> -- -D warnings`
+- **Lint (Rust, pre-commit hook — stricter, gates the commit)**: `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
+- **Tests**: `cargo test --release -p ethos-core` / `cargo test --release --bin <app>`
+- **Lint (frontend)**: `cd <app> && yarn lint`
+- **Type check**: `cd <app> && yarn check`
+- **Build**: `cd <app> && yarn tauri:build`
+- **Run**: `cd <app> && yarn tauri:dev`
+- **Diff check**: grep/diff review for non-compiling stages
+
+## Commit
+Commit message for this stage (only for test stages or stages that produce committed work):
+```
+<type>(<scope>): <description>
+```
+
+## Notes
+Any caveats, known issues, or things the implementer should watch for.
+```
+
+#### Skeleton Stage (001) Specifics
+
+The skeleton stage must:
+- Add all new Rust modules, structs, enums, and error variants with `todo!()`-free compiling stubs (return `Default`, empty collections, or a clear `Err(...)` — never `todo!()`/`unimplemented!()`, which turn a stub into a runtime panic)
+- Declare new modules in their parent `mod.rs` / `lib.rs` / `main.rs`
+- Add `#[tauri::command]` stubs and register them in the app's `invoke_handler`
+- Add matching TypeScript types/interfaces on the frontend
+- Add any new dependencies to the workspace `Cargo.toml` and the package's `Cargo.toml`, or the app's `package.json`
+- Add `// TODO: Implement in Stage NNN` comments marking where each subsequent stage will work
+- Leave `cargo clippy -- -D warnings` clean — dead-code warnings on not-yet-called stubs are the most common way this stage fails
+
+#### Test Stage Specifics
+
+Test stages fall into two categories. The stage author must choose the appropriate category based on what was implemented.
+
+##### Verification Test Stages (post-skeleton, post-minor-change)
+
+For stages where the implementation is stubs, scaffolding, or low-risk changes:
+- Specify the exact commands to run, including package flags
+- Define clear pass/fail criteria
+- End with a commit instruction
+
+##### Functional Test Stages (post-meaningful-implementation)
+
+For stages that implemented behavior a user or external caller will interact with — Tauri commands, git/LFS operations, background workers, UI flows — the test stage must **actually run the code and verify its outputs**. A compile check alone provides false confidence.
+
+Functional test stages must include:
+
+1. **Discovery step**: identify real inputs to test against (an actual repo, actual config, actual files). Do not invent synthetic fixtures when real state is available.
+
+2. **Happy-path exercise**: run the app (`yarn tauri:dev`) or the relevant unit test and invoke each implemented operation with real inputs. Verify the output contains expected data and is correctly shaped. For multi-step flows, exercise the full lifecycle: start → operate → finish.
+
+3. **Error-path exercise**: for each operation, provide at least one invalid input (missing file, dirty repo, no network, cancelled operation). Verify a clean error surfaces to the UI — not a panic, not a silent failure, not a frozen window.
+
+4. **Round-trip verification** (for anything that persists state): mutate → persist → restart the app → verify the mutation survived. Config and cached state that don't round-trip are broken regardless of what other tests say.
+
+5. **Cross-validation** (recommended): confirm the result through an independent path — inspect the file on disk, or run the equivalent `git` command by hand — so a bug where the tool believes it wrote something is caught.
+
+6. **Fix-iterate loop** (explicit step): after running all tests, catalog every failure. For each: diagnose root cause → fix → re-run → repeat. **Do not commit until all checks pass.** Iteration is expected and normal at this stage.
+
+7. **Commit only when clean**: the commit at the end of a functional test stage certifies that the implementation works, not just that it compiles.
+
+##### Choosing the Test Type
+
+| What was implemented | Test type |
+|---------------------|-----------|
+| Skeleton / stubs / scaffolding | Verification |
+| Dependency, config, or formatting changes | Verification |
+| Tauri command with a frontend caller | Functional |
+| Git/LFS operation or external process invocation | Functional |
+| State that persists to disk or config | Functional |
+| Internal refactor with no behavior change | Verification |
+
+When in doubt, use functional. A test stage that over-tests is better than one that under-tests.
+
+### 4. Author the Master Prompt (000)
+
+Create `000-prompt-to-implement-thing.md` in the plan directory:
+
+```markdown
+# Implementation Guide: <Proposal Name>
+
+## Overview
+Brief description of what is being implemented and why.
+
+## Source Proposal
+`$INPUT_PROPOSAL_FILE` — Read this first for full context.
+
+## Branch
+- **Branch**: `llm/<username>/<slug>`
+- **Issue**: `<url or "none">`
+
+## How to Follow the Stages
+
+1. Read this document and the source proposal first
+2. Execute stages in numerical order (001, 002, 003, ...)
+3. Each stage is a self-contained document: `NNN-stage-name.md`
+4. Follow every step in the stage document
+5. Run the validation specified at the end of each stage
+6. Commit when the stage document says to commit
+7. Do not skip ahead — later stages depend on earlier ones
+
+## Stage Summary
+
+| Stage | Name | Type | Description |
+|-------|------|------|-------------|
+| 001   | ...  | Skeleton | ... |
+| 002   | ...  | Test | ... |
+| ...   | ...  | ...  | ... |
+
+## Commands Reference
+
+Setup (once per worktree, and after any `core/ui` change):
+
+| Command | Purpose |
+|---------|---------|
+| `cd core/ui && yarn && yarn package` | Build the shared Svelte component library |
+| `cd <app> && yarn` | Install app frontend dependencies |
+| `mkdir -p <app>/build` | Tauri crates expect the frontend output dir to exist |
+
+Verification:
+
+| Command | Purpose |
+|---------|---------|
+| `cargo fmt --all` | Apply formatting |
+| `cargo fmt --all --check` | Format check (what the pre-commit hook runs) |
+| `cargo clippy --all-features -p <pkg> -- -D warnings` | Lint, CI-equivalent |
+| `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` | Lint, what the pre-commit hook runs — stricter than CI |
+| `cargo test --release -p ethos-core` | Shared crate tests |
+| `cargo test --release --bin <app>` | App tests |
+| `cd <app> && yarn lint` | Prettier + ESLint check |
+| `cd <app> && yarn lint:fix` | Apply frontend fixes (`yarn format` for core/ui) |
+| `cd <app> && yarn check` | svelte-check type validation |
+| `cd <app> && yarn tauri:build` | Build the app (no bundle) |
+| `cd <app> && yarn tauri:dev` | Run the app |
+
+Packages: `ethos-core`, `friendshipper`, `friendshipper-server`. Frontends: `friendshipper`, plus the shared `core/ui` library.
+
+## Tracking Work
+
+- Each test stage commit marks a checkpoint
+- If a stage fails validation, fix it before moving on — do not accumulate debt
+- Plan and stage documents are local-only (`.claude/workflow/` is gitignored); never commit them
+
+## Commit Convention
+
+```
+<type>(<scope>): <description>
+```
+
+Enforced by commitlint via the `commit-msg` hook:
+
+- **type**: one of `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- **scope**: **required**, one of `core`, `friendshipper`, `misc` (use `misc` for repo-wide/tooling; there is no `server` scope)
+- **description**: terse, lower-case, no trailing period
+- No CI tags, no PR numbers
+- Never commit with `--no-verify`
+```
+
+### 5. Present for Review
+
+1. Summarize the breakdown for the user: stage count, the implement/test rhythm, and which stages carry the most risk
+2. Do not begin implementation until the breakdown is approved
+3. Stage files are untracked, so there is nothing to commit or push at this step
+
+## Error Handling
+
+- **Proposal is too vague**: Ask the user for clarification on scope, types, and boundaries before breaking down
+- **Proposal scope is enormous**: Suggest splitting into multiple proposals, each with its own breakdown
+- **Cannot determine type graph**: Document assumptions in stage 001 and flag for review
+- **Circular dependencies in stages**: Restructure stages to break the cycle; consider combining stages if necessary
+
+## Important Notes
+
+- **Do not implement anything during breakdown**: This instruction only produces documents
+- **Stage files are living documents**: The implementer or reviewer may revise stages after initial authoring. The breakdown is a plan, not a contract
+- **Each stage must be independently understandable**: An implementer reading stage 005 should be able to understand what to do without re-reading 001-004 (though they should reference prerequisites)
+- **Prefer more stages over fewer**: Smaller stages are easier to validate, review, and roll back. A stage that takes more than ~30 minutes to implement is probably too large
+- **Reference the standard commands, never re-implement them**: use the commands table above rather than inlining ad-hoc build or test logic
+- **The 000 file is the entry point**: An implementer starting from scratch reads 000 first, then proceeds through the stages. It must be self-sufficient as a starting guide
+- **Test stages for user-facing work are not build wrappers**: A test stage that only runs `cargo clippy` is appropriate after a skeleton stage. For stages implementing Tauri commands, git operations, or UI flows, the test stage must run the code with real inputs, verify real outputs, test error paths, and verify round-trip correctness for anything persisted
+
+## Example Stage Breakdown
+
+For a proposal that adds a submit queue to Friendshipper so concurrent submits are serialized instead of dropped:
+
+```
+000-prompt-to-implement-thing.md   — Master guide
+001-skeleton.md                    — Queue types in core, command stubs, TS types, registration
+002-test-skeleton.md               — fmt + clippy + build clean; commands callable and return stub errors
+003-implement-queue-state.md       — Queue storage, ordering, and state transitions in ethos-core
+004-test-queue-state.md            — Functional: unit tests over enqueue/drain/cancel, including contention
+005-implement-tauri-commands.md    — Wire commands to the queue, surface progress events
+006-test-tauri-commands.md         — Functional: invoke from a running app, verify events and error paths
+007-implement-ui.md                — Queue panel, progress display, cancel affordance
+008-test-ui.md                     — Functional: exercise in tauri:dev, verify happy path + failed submit
+009-final-validation.md            — Both apps build, full lint/test sweep, restart round-trip, code-reading checklist
+```

--- a/.claude/instructions/DoNextWorkflowStep.md
+++ b/.claude/instructions/DoNextWorkflowStep.md
@@ -1,0 +1,1072 @@
+<!-- claude-hint:
+model: opus
+effort: max
+rationale: Creation Workflow orchestrator; stage decisions require depth reasoning; delegates heavy stages to subagents (which have their own hints)
+-->
+
+Do not use instructions from this file unless asked.
+
+# Do Next Workflow Step
+
+This instruction is the orchestrator for the **Creation Workflow** — a multi-stage process that takes a feature idea from initial concept through planning, refinement, implementation, testing, and staging for PR. An instance of Claude Code reading this document should be able to detect the current stage and execute the next step, or start from scratch if no workflow is in progress.
+
+## Overview
+
+The Creation Workflow has 10 steps across 9 numbered stages:
+
+```
+1. Plan              — Clarify intent, research codebase, produce a work proposal
+2A. Refine           — Iterative improvement with user feedback
+2B. Fracture         — Break plan into parallel-editable documents
+3. Singletonize      — Harden each document to stand alone without ambiguity
+4. Loss Checking     — Verify nothing was dropped between original plan and final documents
+5. Sequencing        — Turn the plan into ordered implementation stages (skeleton → test → implement → ...)
+6. Implementing      — Execute the sequenced stages as commits
+7. Testing           — Verify fmt/clippy/tests/lint pass on a rebased branch, debug failures
+8. Staging           — Archive plan docs, rebase on main, run lint/format, squash, write the final commit, push, create PR
+9. Review Gate       — Human reviews and approves the PR; PR squash-merges
+```
+
+## Where Workflow Artifacts Live
+
+**All workflow artifacts are local-only and never committed.** `.gitignore` ignores `.claude/*` and re-includes only the shared tooling (`README.md`, `instructions/`, `scripts/`, `skills/`), so `.claude/workflow/` — every plan document, stage file, and state file — stays out of the repository.
+
+```
+.claude/workflow/<work-slug>/          # active workflow: plan docs, stage files, WORKFLOW_STATE.json
+.claude/workflow/archive/<work-slug>/  # design docs preserved after staging
+```
+
+Consequences that differ from a workflow that commits its plans:
+
+- Plan documents are **not** committed to the work branch, so there is no "delete the plan docs before squashing" step. Instead, Stage 8 **verifies** that no workflow artifacts leaked into the diff.
+- Loss checking (Stage 4) cannot diff plan commits from git history. Stage 1 therefore writes an immutable snapshot, `00-original-plan.md`, that Stage 4 compares against.
+- Workflow state does not travel between machines or worktrees. One worktree owns one workflow.
+
+## Stage Model/Effort Hints
+
+When executing a stage that spawns subagents, pass these model/effort overrides to `Agent(...)` calls. The table below captures the default policy; stage sections (1-9) may override per case.
+
+| Stage | Recommended model | Recommended effort | Rationale |
+|---|---|---|---|
+| 1. Plan | `opus` | `max` | Intent clarification, codebase research, design |
+| 2A. Refine | `opus` | `high` | Iterative improvement with feedback |
+| 2B. Fracture | `sonnet` | `high` | Mechanical doc splitting w/ context preservation |
+| 3. Singletonize | `sonnet` | `high` | Cross-check against codebase, fill gaps |
+| 4. Loss Checking | `sonnet` | `medium` | Diff original vs final for dropped content |
+| 5. Sequencing | `opus` | `high` | Ordered implementation plan |
+| 6. Implementing | per-stage | per-stage | Each `NNN-stage-name.md` gets its own hint (mostly `sonnet`/`medium`; `opus`/`high` for architecturally sensitive stages) |
+| 7. Testing | `sonnet` | `medium` | Build + test execution, failure triage |
+| 8. Staging | `sonnet` | `medium` | Squash rebase + archive + PR create; needs care because force-push is destructive |
+| 9. Review Gate | `haiku` | `low` | CI poll + status summary |
+
+## Git Command Convention
+
+**Use `git -C <repo>` instead of `cd <repo> && git ...`** for all git commands. This avoids compound shell commands (`cd && git`) which trigger unnecessary permissions prompts in Claude Code, even for trusted repositories. Determine the repo path from the current working directory or worktree root once (`git rev-parse --show-toplevel`), then pass it via `-C` for every git invocation.
+
+**Invocation protocol**: Every time this document is invoked, the orchestrator must:
+1. Detect the current workflow stage (see [State Detection](#state-detection))
+2. Describe what the next action will be to the user
+3. Wait for user approval before executing (unless the user has opted into auto-advance)
+4. Execute the stage
+5. Update `WORKFLOW_STATE.json` with the new state
+6. Report results and what comes next
+
+---
+
+## Repo Reference: Commands and Conventions
+
+Everything below is verified against `.github/workflows/rust.yml` and the app `package.json` files. Stage documents should reference these commands rather than inventing their own.
+
+### Workspace layout
+
+| Path | Cargo package | Notes |
+|---|---|---|
+| `core/` | `ethos-core` | Shared Rust crate |
+| `core/ui/` | — | `@ethos/core` Svelte component library, consumed by the app frontends |
+| `friendshipper/` + `friendshipper/src-tauri/` | `friendshipper` | Tauri app (bin target `friendshipper`) |
+| `friendshipper/server/` | `friendshipper-server` | Headless server, also shipped as a container image |
+
+### Setup (required before Rust checks on a fresh worktree)
+
+The Tauri crate expects a frontend output directory to exist, and the app frontend consumes the packaged `core/ui` library. CI does this first, and so should you:
+
+```bash
+cd core/ui && yarn && yarn package     # build the shared component library
+cd friendshipper && yarn               # app frontend deps
+mkdir -p friendshipper/build
+```
+
+### Verification commands (mirror of CI)
+
+`.github/workflows/rust.yml` is authoritative for which apps and packages CI actually builds; check its job matrices if a check here seems not to apply.
+
+| Purpose | Command |
+|---|---|
+| Rust format check | `cargo fmt -p ethos-core -- --check` (repeat for `friendshipper`, `friendshipper-server`) |
+| Rust format fix | `cargo fmt --all` |
+| Clippy (CI-strict) | `cargo clippy --all-features -p <package> -- -D warnings` |
+| Unit tests | `cargo test --release -p ethos-core`, `cargo test --release --bin friendshipper`, `cargo test --release -p friendshipper-server` |
+| Frontend lint | `cd <core/ui\|friendshipper> && yarn lint` |
+| Frontend lint fix | `yarn lint:fix` (apps) / `yarn format` (`core/ui`) |
+| Svelte type check | `cd <app> && yarn check` (not in CI, but catches real type errors) |
+| Full app build | `cd <app> && yarn tauri:build` |
+| Run the app | `cd <app> && yarn tauri:dev` |
+
+Notes:
+- Clippy is `-D warnings` in CI. A warning is a failure.
+- `yarn lint` runs prettier in check mode; formatting-only failures are common and are fixed with `yarn lint:fix`.
+- There is no remote build-verification service for this repo. Build locally, then let PR CI (Linux + Windows) confirm.
+
+### Git hooks (the real gate — stricter than CI)
+
+`core.hooksPath` is set to `friendshipper/.husky`, so **every local commit** runs:
+
+| Hook | Runs |
+|---|---|
+| `pre-commit` | `npx lint-staged` in `core/ui` and `friendshipper` (eslint `--fix` + prettier `--write` on staged files, re-staged automatically), then `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`, then `cargo fmt --all --check` |
+| `commit-msg` | `npx commitlint --edit --cwd friendshipper` |
+
+Consequences:
+
+- The pre-commit clippy is **stricter than CI**: nightly toolchain, whole workspace, `--all-targets` (so test and bench code is linted too). Code that passes the CI-equivalent commands in the table above can still be rejected locally. Requires a nightly toolchain — `rustup toolchain install nightly` if `cargo +nightly` fails.
+- `cargo fmt --all --check` runs on every commit, so formatting can never drift. Run `cargo fmt --all` before committing.
+- lint-staged only touches **staged** files. Unstaged frontend files are not formatted, which is why a full `yarn lint` is still worth running before staging the branch.
+- **Never bypass with `--no-verify`.** If a hook fails, fix the cause. If the user explicitly asks to bypass, say what is being skipped.
+
+### Commit conventions
+
+Conventional commits, **enforced by commitlint** (`friendshipper/.commitlintrc.json`) — a non-conforming message is rejected by the `commit-msg` hook:
+
+```
+<type>(<scope>): <description>
+```
+
+- **type** (required, from `type-enum`): `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- **scope** (required — `scope-empty` is `never`, so a bare `fix: ...` is rejected) from `scope-enum`: `core`, `friendshipper`, `misc`
+  - Use `misc` for repo-wide or tooling changes. There is **no** `server` scope — changes to `friendshipper/server` go under `friendshipper` or `misc`.
+- **description**: terse, lower-case, no trailing period
+- No CI tags. This repo's CI runs on every PR; there is nothing to opt into.
+- GitHub appends the PR number on squash-merge — do not add it by hand.
+
+Note: some commits on `main` (bot version bumps, scope-less messages) do not satisfy these rules, because GitHub composes squash-merge subjects server-side and never runs the local hooks. Local commits still must conform.
+
+### Branch conventions
+
+| Kind | Pattern | Pushed? |
+|---|---|---|
+| Parking | `llm/<username>/<worktree>-parking-<YYYYMMDD>` | Never |
+| Work (no issue) | `llm/<username>/<slug>` | Yes |
+| Work (with issue) | `llm/<username>/<issue-number>-<slug>` | Yes |
+
+`<username>` is the local part of `git config user.email`. `<slug>` is short kebab-case. Human-authored branches in this repo use `<initials>/<slug>`; the `llm/` prefix marks agent-driven work and keeps the two sets easy to tell apart.
+
+---
+
+## State File: WORKFLOW_STATE.json
+
+The workflow tracks its progress via a `WORKFLOW_STATE.json` file located **in the plan directory** (`.claude/workflow/<work-slug>/`). This file is the primary source of truth for workflow state.
+
+### Schema
+
+```json
+{
+  "version": 1,
+  "stage": "plan|refine|fracture|singletonize|loss_check|sequencing|implementing|testing|staging|review_gate|complete",
+  "stage_detail": "Free-text description of where within the stage we are",
+  "plan_document": "path to the primary plan document, relative to repo root",
+  "plan_directory": ".claude/workflow/<work-slug>",
+  "branch": "git branch name for this workflow",
+  "worktree": "absolute path of the worktree that owns this workflow",
+  "issue_url": "GitHub issue URL (if one exists)",
+  "pr_url": "Pull request URL (created during staging)",
+  "created": "ISO 8601 timestamp of workflow start",
+  "last_updated": "ISO 8601 timestamp of last state change",
+  "auto_advance": false,
+  "refinement_history": [
+    {
+      "timestamp": "ISO 8601",
+      "action": "description of what was done",
+      "user_feedback": "summary of user feedback that prompted this iteration"
+    }
+  ],
+  "fractured_documents": ["list of document paths after fracturing"],
+  "sequenced_stages": ["list of NNN-stage-name.md paths after sequencing"],
+  "implementation_progress": {
+    "current_stage": "NNN",
+    "completed_stages": ["001", "002"],
+    "failed_stages": []
+  }
+}
+```
+
+Timestamps: read the current time from the environment context or `git log -1 --format=%cI`; do not invent one.
+
+---
+
+## State Detection
+
+When invoked, determine the current stage using this priority order:
+
+### 1. Primary: Read WORKFLOW_STATE.json
+
+Search for `WORKFLOW_STATE.json` under `.claude/workflow/` (excluding `archive/`). If exactly one is found, read it and trust the `stage` field. Validate by spot-checking:
+
+- Does the `branch` match the current git branch?
+- Does `worktree` match the current worktree root? If not, this workflow belongs to a different worktree — warn the user and do not modify it.
+- Do the referenced files still exist?
+- If validation fails, warn the user and offer to re-detect via heuristics.
+
+If more than one is found, list them and ask the user which workflow to advance.
+
+### 2. Fallback: Heuristic Detection
+
+If no `WORKFLOW_STATE.json` exists:
+
+| Condition | Detected Stage |
+|-----------|---------------|
+| On a parking branch (`*-parking-*`) or `main` | **No workflow in progress** — start Stage 1 |
+| On a work branch with no plan directory under `.claude/workflow/` | **Stage 1** — planning not yet started or just beginning |
+| Plan document exists but no `*_REVIEW.md` and no fractured docs | **Stage 2A** — ready for refinement |
+| Plan document exists with fractured subdocuments | **Stage 2B → 3** — check if documents are self-contained |
+| Numbered stage files exist (`NNN-*.md`) | **Stage 5 complete → 6** — ready for implementation |
+| Stage files exist and the branch has commits beyond `origin/main` | **Stage 6 → 7** — implementation in progress or ready for testing |
+| Local verification commands pass | **Stage 7 → 8** — ready for staging |
+| PR exists and branch is more than one commit ahead of main | **Stage 8** — resume staging (squash and push not yet done) |
+| PR exists, branch is squashed, not yet approved | **Stage 9** — awaiting human review |
+| PR exists and is approved | **Stage 9** (terminal) — merge, no further workflow steps |
+
+When using heuristic detection, **always confirm the detected stage with the user** before proceeding.
+
+### 3. Fresh Start
+
+If on a parking branch or main with no workflow state:
+- Inform the user that no workflow is in progress
+- Ask if they want to start a new Creation Workflow (Stage 1)
+- If yes, proceed to Stage 1
+
+---
+
+## Stage 1: Plan
+
+**Entry condition**: No active workflow, or `stage == "plan"`
+**Goal**: Clarify the user's intent and produce a grounded work proposal document
+
+### Process
+
+#### 1.1 Clarify Intent
+
+Engage the user in an iterative Q&A to fully specify what they want:
+- What is the feature or change?
+- Which surface does it affect — the `friendshipper` app, the shared `ethos-core` crate, the shared `core/ui` component library, or `friendshipper/server`?
+- Is this Rust-side, frontend-side, or both? Does it cross the Tauri command boundary?
+- What is the desired user experience?
+- What are the boundaries / what is explicitly out of scope?
+- Are there constraints around git/LFS behavior, long-running operations, cross-platform support (Windows + Linux are both built in CI), or config/persistence?
+
+Ask questions until the request is unambiguous. Use `AskUserQuestion` for enumerable choices, free-text for open-ended exploration. **Do not stop at the first answer** — dig into implications, edge cases, and integration points.
+
+#### 1.2 Research
+
+Using the ethos source:
+- Identify the existing systems the feature must integrate with (Rust modules in `core/src` and `<app>/src-tauri/src`, Tauri commands, Svelte routes/stores in `<app>/src`, shared components in `core/ui/src`)
+- Trace the full path for anything user-visible: Svelte component → Tauri `invoke` → command handler → core operation
+- Find relevant structs, traits, and state containers (e.g. long-running operation handling, git/LFS wrappers, config types)
+- Identify existing patterns the implementation should follow, and note prior art that solves a similar problem differently
+- For third-party crate or Tauri/Svelte API questions, verify against the actual dependency version in `Cargo.toml` / `package.json`; use `WebFetch`/`WebSearch` against docs.rs or upstream docs rather than guessing
+
+This research must produce **concrete references** to actual code — not guesses about what might exist. The plan should be grounded in the real codebase.
+
+#### 1.3 Write the Work Proposal
+
+Create the plan directory `.claude/workflow/<work-slug>/` and write the proposal there, named descriptively (e.g. `SUBMIT_QUEUE_PROPOSAL.md`). The proposal should contain:
+
+- **Goal**: What this achieves and why it matters
+- **Scope**: What's included and explicitly excluded
+- **Architecture**: How this fits into the existing system, which crates/apps/modules are affected
+- **Technical Design**: Key types, traits, Tauri commands, state, and UI surfaces — referencing actual existing code
+- **Dependencies**: What must exist before this can be built; any new crates or npm packages (call these out explicitly, they need review)
+- **Cross-platform notes**: Anything that behaves differently on Windows vs Linux
+- **Risks**: What could go wrong, what's uncertain
+- **Open Questions**: Anything not yet resolved
+
+The proposal should be detailed enough that a senior engineer could evaluate feasibility, but high-level enough that it describes *what* and *why* rather than dictating *how* line-by-line. Avoid writing implementation code in the proposal.
+
+#### 1.4 Snapshot for Loss Checking
+
+Copy the approved proposal verbatim to `.claude/workflow/<work-slug>/00-original-plan.md`. **Never edit this file again** — Stage 4 diffs the final documents against it. Because plan docs are not committed, this snapshot is the only record of the original intent.
+
+#### 1.5 Present for Review
+
+Show the proposal to the user. If they approve, create the work branch.
+
+#### 1.6 Create Work Branch
+
+```bash
+git -C <repo> fetch origin main
+git -C <repo> switch -c "llm/<username>/<slug>" origin/main
+```
+
+If the user wants issue tracking, create or link a GitHub issue and use `llm/<username>/<issue>-<slug>`:
+
+```bash
+gh issue create --title "<title>" --body "<goal + scope summary>"
+```
+
+Do not push yet — the branch has no commits, and plan documents are not committed. The branch is first pushed in Stage 8. If the user wants early visibility, push an empty branch (`git -C <repo> push -u origin <branch>`) and note it in the state file.
+
+#### 1.7 Update State
+
+Create `WORKFLOW_STATE.json` in the plan directory with `stage: "refine"`, and record `branch`, `worktree`, `plan_document`, `plan_directory`, and `issue_url` if one exists.
+
+**Exit condition**: Plan document written, snapshot taken, work branch created, state file created.
+
+---
+
+## Stage 2A: Refine
+
+**Entry condition**: `stage == "refine"`
+**Goal**: Iteratively improve the plan with user feedback
+
+### Important Principles
+
+- **Refinement requires fresh user input**. Running the automated review in a loop without user feedback does not improve the plan — it tends toward "implementation-as-instructions" where code ends up written inside the plan document.
+- The plan should remain a **high-level design document**, not a set of copy-paste instructions.
+- Each refinement cycle should incorporate the user's perspective, domain knowledge, or changed requirements.
+
+### Process
+
+When entering this stage, present the user with their options:
+
+> **The plan is ready for refinement.** How would you like to proceed?
+
+Offer these tools/actions:
+
+1. **Run automated review** — Invoke [RefineProposal.md](RefineProposal.md) to catch internal inconsistencies, verify source code references, and generate a structured review document. Useful as a starting point for discussion, not as a final product.
+
+2. **Generate a diagram** — Produce a mermaid chart for a specific aspect of the design (data flow across the Tauri boundary, state machine, sequence diagram, module dependencies). Embed it in the plan or present it separately.
+
+3. **Publish a shareable summary** — If the user wants to share the design outside the terminal, render it as an Artifact.
+
+4. **Update the GitHub issue** — If an issue exists for this work, sync the current plan state to it (goal, scope, open questions).
+
+5. **Provide feedback directly** — The user gives free-text feedback, asks questions, or requests specific changes to the plan.
+
+6. **Mark refinement complete** — The user is satisfied with the plan and wants to move to the next stage.
+
+After each refinement cycle:
+- Record the iteration in `WORKFLOW_STATE.json`'s `refinement_history` array
+- Update the plan document with changes (never `00-original-plan.md`)
+- Ask the user what they'd like to do next (loop back to options above)
+
+### Before Marking Complete
+
+Ensure the plan document itself is a complete record: goal, scope (including what was explicitly excluded), technical design per feature with file impacts and API shapes, architecture, numbered key decisions with rationale, risks with mitigations, and where the work originated. Anyone reading only this document should have full context without reconstructing the conversation.
+
+If a GitHub issue exists, sync a condensed version of that summary to it — the issue is the only part of this record that survives outside the local machine.
+
+**Exit condition**: User explicitly marks refinement complete. Update state to `stage: "fracture"`.
+
+---
+
+## Stage 2B: Fracture
+
+**Entry condition**: `stage == "fracture"`
+**Goal**: Break the plan into multiple documents to enable parallel editing and clear ownership of sections
+
+### When to Fracture
+
+Fracturing is required when:
+- The plan is complex enough that editing one section could inadvertently affect another
+- Multiple aspects of the plan benefit from independent, focused attention
+- The eventual implementation will have clear module boundaries that map to document boundaries
+
+If the plan is small (a single-crate change, one UI surface), say so and skip to Stage 3 with the user's agreement — record the skip in `stage_detail`.
+
+### Process
+
+#### 2B.1 Design the Document Structure
+
+Analyze the plan and identify natural boundaries:
+- By layer (e.g. `SUBMIT_core-rust.md`, `SUBMIT_tauri-commands.md`, `SUBMIT_ui.md`)
+- By component (e.g. `<NAME>_shared-core.md`, `<NAME>_app.md`, `<NAME>_server.md`)
+- By concern (e.g. `<NAME>_architecture.md`, `<NAME>_persistence.md`, `<NAME>_error-handling.md`)
+
+Each fractured document should:
+- Have a clear, non-overlapping scope
+- Reference (but not duplicate) content from other documents
+- Be editable independently without breaking coherence
+
+#### 2B.2 Execute the Fracture
+
+1. Keep the original plan document as the "overview" document in the plan directory
+2. Create individual documents for each identified section
+3. Add cross-references between documents
+4. Update `WORKFLOW_STATE.json` with the `fractured_documents` list
+
+`00-original-plan.md` stays untouched.
+
+#### 2B.3 Parallel Refinement (Optional)
+
+After fracturing, individual documents can be refined using sub-agents working in parallel. Each sub-agent:
+- Reads only its assigned document plus the overview
+- Makes focused improvements
+- Does not modify other documents
+
+This is optional and depends on the user's preference and the complexity of the plan.
+
+**Exit condition**: Plan is fractured into self-contained documents. Update state to `stage: "singletonize"`.
+
+---
+
+## Stage 3: Singletonize
+
+**Entry condition**: `stage == "singletonize"`
+**Goal**: Harden every document so it can be implemented with zero ambiguity by a less-capable agent
+
+### Principles
+
+- This is **not further iteration on the design**. The design decisions are made. This stage clarifies what is written.
+- Every document must contain everything needed to implement its scope without consulting other documents (though it may reference them for context).
+- Assumptions and prerequisites must be made explicit.
+- Vague language ("as needed", "appropriate", "similar to") must be replaced with specifics.
+
+### Process
+
+For each document in the plan:
+
+#### 3.1 Verify Against Codebase
+
+- Confirm every referenced module, type, function, Tauri command, Svelte component, and file path still exists
+- Verify that described interfaces match actual signatures (Rust fn signatures, `#[tauri::command]` parameter names, serde field names, TypeScript types)
+- Check that assumed behaviors match actual implementations
+- Update any stale references
+
+#### 3.2 Expose Assumptions
+
+Scan for implicit assumptions and make them explicit:
+- "This will use the existing X" → verify X exists and describe exactly how it will be used
+- "The system handles Y" → specify which module, which function, what inputs/outputs
+- "Follows the existing pattern" → name the pattern and cite a concrete example file in the repo
+- Serialization: state the exact wire shape crossing the Tauri boundary, including serde rename/case conventions
+
+#### 3.3 Fill Gaps
+
+Identify and fill any missing information:
+- Missing error handling — which error type, how it surfaces to the UI
+- Unspecified edge cases
+- Unclear ordering of operations, and anything that must not block the UI thread
+- Missing type definitions on either side of the boundary
+- Unaddressed persistence/config migration concerns
+- Cross-platform path or process handling
+
+#### 3.4 Simplify for Implementation
+
+Rewrite complex descriptions so they are implementable as direct instructions:
+- Replace "consider using X or Y" with a decision: "use X because [reason]"
+- Replace "the system should handle [vague scenario]" with specific behavior descriptions
+- Ensure every described behavior maps to a concrete implementation action
+
+**Exit condition**: All documents are self-contained, unambiguous, and verified against the codebase. Update state to `stage: "loss_check"`.
+
+---
+
+## Stage 4: Loss Checking
+
+**Entry condition**: `stage == "loss_check"`
+**Goal**: Verify that nothing from the original plan or refinement feedback was dropped, ignored, or distorted
+
+### Process
+
+#### 4.1 Gather the Record
+
+1. **Original plan**: `.claude/workflow/<work-slug>/00-original-plan.md` (the immutable Stage 1 snapshot)
+2. **Refinement feedback**: the `refinement_history` array in `WORKFLOW_STATE.json`
+3. **Current state**: the hardened, singletonized documents
+
+#### 4.2 Compare
+
+For each piece of the original plan and each piece of refinement feedback:
+- Is it present in the final documents?
+- If it was intentionally removed or changed, is the reason documented?
+- If it was split across multiple documents, is the full intent preserved?
+
+#### 4.3 Report
+
+Produce a brief **loss report** (`LOSS_REPORT.md` in the plan directory) documenting:
+- Items preserved faithfully
+- Items modified (with justification)
+- Items intentionally dropped (with justification)
+- Items **unintentionally dropped** (these need to be restored or explicitly addressed)
+
+If unintentional losses are found:
+- Present them to the user
+- Ask whether to restore them or explicitly mark them as out of scope
+- Update the documents accordingly
+
+**Exit condition**: All plan content is accounted for. Update state to `stage: "sequencing"`.
+
+---
+
+## Stage 5: Sequencing
+
+**Entry condition**: `stage == "sequencing"`
+**Goal**: Turn the plan into an ordered sequence of implementable stages
+
+### Process
+
+Invoke **[BreakDownWorkProposal.md](BreakDownWorkProposal.md)** with the plan document(s) as input.
+
+### Important Modifications for This Workflow
+
+The sequencing step from BreakDownWorkProposal.md should be applied with these additional considerations:
+
+#### Test Rigor Depends on Implementation Structure
+
+- **Sequential, stacking implementation** (each phase builds on the last): Tests at each stage must **actually verify** that the implementation compiles and functions correctly before moving on. This is test-verified implementation — not test-driven development, but each layer must be solid before the next is added.
+
+- **Independent, parallel implementation** (phases are unrelated to each other, e.g. several standalone Tauri commands or unrelated UI panels): compile/clippy verification can be batched — a single check after several independent units is fine, since fixing an error in unit A won't affect unit B. However, **functional testing** should not be deferred if the individual units have behavioral depth (state mutation, persistence, external process invocation, error paths). Each unit that has external callers or persists state still needs its own functional test stage. What can be deferred is only the integration test across units.
+
+The sequencing step should explicitly identify which pattern applies and annotate the stage files accordingly.
+
+#### Entry Point
+
+The output must include `000-prompt-to-implement-thing.md` as the single entry point. This file must:
+- Reference the source proposal for full context
+- List all stages in order with brief descriptions
+- Include the branch name and issue URL (if any)
+- Provide the commands reference table
+- Explain the test rigor expectations for this specific breakdown
+
+### Post-Sequencing
+
+After BreakDownWorkProposal produces the stage files:
+1. Review the breakdown for completeness
+2. Update `WORKFLOW_STATE.json` with the `sequenced_stages` list
+3. Present the breakdown to the user for review
+
+**Exit condition**: Stage files written and reviewed. Update state to `stage: "implementing"`.
+
+---
+
+## Stage 6: Implementing
+
+**Entry condition**: `stage == "implementing"`
+**Goal**: Execute the sequenced stages as commits
+
+### Process
+
+#### 6.1 Determine Starting Point
+
+Read `WORKFLOW_STATE.json`'s `implementation_progress` to find where to resume:
+- If `current_stage` is set, resume from that stage
+- If no progress recorded, start from stage `001`
+
+#### 6.2 Execute Stages
+
+For each stage, in order:
+
+1. Read the stage document (`NNN-stage-name.md`)
+2. **Use sub-agents** for implementation — each stage should be delegated to a sub-agent with the stage document, the source proposal, and relevant context. This preserves the orchestrator's context window for coordination.
+3. **Cost optimization**: Read the stage document's front-of-file `<!-- claude-hint -->` block if present, or check the hint table in this document's "Stage Model/Effort Hints" section. Pass matching `model:`/`effort:` values to the subagent invocation via `Agent({ model: "...", ... })`. If no hint is available, default to `sonnet`/`medium`.
+4. After the sub-agent completes, verify the stage's validation criteria
+5. If validation passes, commit per the stage document's instructions (source/asset changes only — plan documents are not committed)
+6. Update `implementation_progress` in `WORKFLOW_STATE.json`
+7. If validation fails, attempt debugging (possibly with a higher-cost sub-agent), then retry
+
+#### 6.3 Progress Tracking
+
+After each stage:
+- Update `WORKFLOW_STATE.json` with progress
+- If a stage fails repeatedly (3+ attempts), mark it as failed and inform the user
+
+#### 6.4 Make Maximum Progress
+
+The implementing stage should push through as many stages as possible in a single invocation. Do not stop after each stage to ask the user — keep going until:
+- All stages are complete
+- A stage fails and cannot be resolved
+- The context window is getting full (delegate more aggressively to sub-agents)
+- The user intervenes
+
+**Exit condition**: All implementation stages complete. Update state to `stage: "testing"`.
+
+---
+
+## Stage 7: Testing
+
+**Entry condition**: `stage == "testing"`
+**Goal**: Verify the full CI-equivalent check set passes on a rebased branch
+
+### Process
+
+#### 7.1 Rebase on Latest Main
+
+```bash
+git -C <repo> fetch origin main
+git -C <repo> rebase origin/main
+```
+
+If conflicts arise, resolve them. This is part of the "test" — the implementation must work with the latest codebase, not just the snapshot it was developed against.
+
+#### 7.2 Reproduce CI Locally
+
+Run the same checks CI runs, for every package the diff touches (determine them with `git -C <repo> diff --name-only origin/main...HEAD`):
+
+```bash
+# Prerequisites (once per worktree, or after core/ui changes)
+cd core/ui && yarn && yarn package
+mkdir -p friendshipper/build
+
+# Rust
+cargo fmt -p <package> -- --check
+cargo clippy --all-features -p <package> -- -D warnings
+cargo test --release -p ethos-core
+cargo test --release --bin friendshipper
+
+# Frontend (per affected package: core/ui, friendshipper)
+cd <app> && yarn && yarn lint
+```
+
+Always run the `ethos-core` checks when `core/` changed — every other package depends on it.
+
+Also run the stricter check the `pre-commit` hook will apply, since it gates every commit in this stage and in Stage 6:
+
+```bash
+cargo fmt --all --check
+cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+#### 7.3 Build Verification
+
+For changes that touch Rust in a Tauri crate or the frontend build, do a real build of each affected app:
+
+```bash
+cd <app> && yarn tauri:build
+```
+
+`--no-bundle` is already baked into the `tauri:build` script, so this is the fast form of the CI build. Fix any build errors.
+
+#### 7.4 Functional Verification
+
+Compile-clean is not "working". For anything user-visible, run the app and exercise the change:
+
+```bash
+cd <app> && yarn tauri:dev
+```
+
+Verify the happy path and at least one error path. If the change cannot reasonably be exercised locally (needs remote infrastructure, specific repo state, or platform-specific behavior), say so explicitly and list what a human must verify — do not silently claim it works.
+
+#### 7.5 Debug and Fix Failures
+
+For each failure:
+1. Diagnose the root cause
+2. Fix the implementation
+3. Re-run the failing check
+4. Ensure the fix doesn't break other checks
+
+Common CI-only failure classes worth checking proactively on the diff:
+- Prettier formatting in Svelte/TS files (`yarn lint` fails where the code is otherwise fine — fix with `yarn lint:fix`)
+- Clippy lints that are warnings locally but fatal in CI (`-D warnings`)
+- Windows/Linux differences: path separators, path case, process spawning, line endings
+- `cargo fmt` on files touched only via search-and-replace
+
+#### 7.6 Commit Fixes
+
+Commit any fixes as additional commits (they'll be squashed in staging).
+
+**Exit condition**: All checks pass on the rebased branch. Update state to `stage: "staging"`.
+
+---
+
+## Stage 8: Staging
+
+**Entry condition**: `stage == "staging"`
+**Goal**: Archive plan documents, rebase onto latest main, run the lint/format pipeline, squash, write the final commit, push the merge-ready branch, create the PR
+
+### Process
+
+#### 8.1 Archive Plan Documents
+
+Copy the design documents from the plan directory into `.claude/workflow/archive/<work-slug>/`. These documents capture the intent, reasoning, and design decisions behind the work.
+
+What to archive:
+- The plan/proposal document(s), including `00-original-plan.md`
+- Fractured design documents
+- Singletonized documents
+- `LOSS_REPORT.md`
+- Any review documents (`*_REVIEW.md`) and diagrams
+- `000-prompt-to-implement-thing.md`
+
+What NOT to archive (mechanical workflow artifacts):
+- `WORKFLOW_STATE.json`
+- Individual `NNN-stage-name.md` implementation instruction files (except `000-*`)
+
+`<work-slug>` should be concise kebab-case (e.g. `submit-queue`, `lfs-lock-cache`).
+
+Do not rewrite or clean up these documents. This is an archive, not a documentation database — copy them as-is to preserve the original context. The archive is local and gitignored; it is a record of intent, not a claim that the work merged.
+
+#### 8.2 Verify No Workflow Artifacts Leaked Into the Diff
+
+Plan documents are supposed to be untracked. Confirm it:
+
+```bash
+git -C <repo> diff --name-only origin/main...HEAD
+```
+
+If any path under `.claude/workflow/` appears, remove it from the branch before continuing (it was force-added past `.gitignore`). Paths under `.claude/skills/`, `.claude/instructions/`, and `.claude/scripts/` **are** tracked, so those may legitimately appear if this work changed the tooling itself. Also confirm the working tree has no stray debug scaffolding:
+
+```bash
+git -C <repo> status --porcelain
+```
+
+#### 8.3 Rebase onto Latest Main
+
+```bash
+git -C <repo> fetch origin main
+git -C <repo> rebase origin/main
+```
+
+If conflicts arise, resolve them carefully — main may have moved significantly since implementation began.
+
+Do **not** squash yet. The lint pass in 8.4 has to run against the rebased tree, and its fixes belong *inside* the squashed commit rather than amended onto it afterward.
+
+#### 8.4 Run the Lint/Format Pipeline
+
+This is a required gate, not a formality: the `pre-commit` hook runs `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all --check` on every commit, so an unclean tree cannot even be committed in 8.5.
+
+**1. Scope the work.**
+
+```bash
+git -C <repo> diff --name-only origin/main...HEAD
+```
+
+Map changed paths to packages. `core/` changes mean `ethos-core` plus every package that depends on it. `core/ui/` changes mean re-packaging the library and re-linting each frontend that consumes it.
+
+**2. Satisfy the prerequisites.** Clippy on the Tauri crate needs the frontend output dir to exist, and the frontend consumes the packaged library:
+
+```bash
+cd core/ui && yarn && yarn package
+mkdir -p friendshipper/build
+```
+
+**3. Apply formatting and auto-fixes.**
+
+```bash
+cargo fmt --all
+cd core/ui && yarn format          # if core/ui changed
+cd <app> && yarn lint:fix          # per affected app (prettier --write + eslint --fix)
+```
+
+**4. Verify clean — mirror both the hook and CI.**
+
+```bash
+cargo fmt --all --check
+cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings   # what pre-commit enforces
+cargo clippy --all-features -p <package> -- -D warnings                         # what CI enforces, per affected package
+cd <app> && yarn lint              # per affected app, and core/ui if it changed
+cd <app> && yarn check             # optional; catches type errors CI does not
+```
+
+Run the nightly workspace clippy even when only one package changed — it is the check that will actually block the commit, and `--all-targets` lints test code that the CI command skips. If `cargo +nightly` is missing, install it (`rustup toolchain install nightly`) rather than working around the hook.
+
+**5. Re-test if lint changed behavior.** Formatting is safe, but clippy fixes sometimes alter logic (iterator rewrites, borrow changes). If any fix touched more than style, re-run the affected tests:
+
+```bash
+cargo test --release -p ethos-core
+cargo test --release --bin <app>
+```
+
+**6. Commit the fixes.** Land them as an ordinary commit — the squash in 8.5 folds it in:
+
+```bash
+git -C <repo> add -A
+git -C <repo> commit -m "style(<scope>): apply fmt and lint fixes"
+```
+
+If nothing changed, skip the commit and continue.
+
+**Never pass `--no-verify` anywhere in this stage.** The hook runs the same checks you just ran; if it fails, something here was skipped or a check was run against the wrong package set.
+
+#### 8.5 Squash onto Main
+
+**Idempotency check first**:
+
+```bash
+git -C <repo> rev-list --count origin/main..HEAD
+```
+
+- Output `1` — already squashed by a previous Stage 8 run; skip to 8.6 to verify the commit message.
+- Output `0` — the branch has nothing on top of main; abort with an error.
+- Output `>= 2` — squash now.
+
+Interactive rebase is not available in this environment, so squash with `reset --soft`. The rebase in 8.3 already put HEAD on top of `origin/main`, so this is a pure history collapse:
+
+```bash
+git -C <repo> diff origin/main --stat        # record the tree state before
+git -C <repo> reset --soft origin/main       # keep the tree, drop the commits
+git -C <repo> commit -F <message-file>       # single squashed commit (see 8.6)
+git -C <repo> diff origin/main --stat        # must match the "before" output exactly
+```
+
+If the two `diff --stat` outputs differ, stop and investigate before pushing.
+
+This commit runs the hooks again: the tree must already be clean from 8.4, and the message must satisfy commitlint (8.6). Using `-F <message-file>` keeps the multi-line message intact and lets commitlint see exactly what will be recorded.
+
+#### 8.6 Write the Squashed Commit Message
+
+```
+<type>(<scope>): <description>
+
+<optional body>
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+```
+
+Format requirements (enforced by the `commit-msg` hook — see [Commit conventions](#commit-conventions)):
+- `<type>` from: `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- `<scope>` is **required** and must be one of: `core`, `friendshipper`, `misc`
+- Lower-case description, no trailing period
+- No CI tags — this repo has none
+- Do not add a PR number; GitHub adds it on squash-merge
+- The `Co-Authored-By` trailer follows the agent-authorship convention. This repo's existing history does not carry these trailers; if the user prefers to match repo history, omit it — ask once and record the answer in `WORKFLOW_STATE.json`.
+
+Example:
+
+```
+feat(friendshipper): add submit queue with retry on lock contention
+```
+
+If commitlint rejects the message, it will name the failing rule. Fix the message — do not bypass the hook.
+
+#### 8.7 Push and Create the PR
+
+```bash
+git -C <repo> push -u origin <branch-name> --force-with-lease
+```
+
+Modern git (>= 2.30) treats a missing remote ref as "no expected value" and succeeds with a normal fast-forward push, so no fallback path is required for the first push of a new branch. Subsequent re-staging passes (e.g. after a testing → staging cycle) use `--force-with-lease` against the existing remote ref.
+
+Then create the PR:
+
+```bash
+gh pr create --title "<conventional-commit-style title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet points describing the changes>
+
+## Test plan
+- [ ] `cargo fmt --all --check` and `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] `cargo test` passes for affected packages
+- [ ] `yarn lint` passes for affected frontends
+- [ ] `yarn tauri:build` succeeds for affected apps
+- [ ] Change exercised in a running app (happy path + one error path)
+- [ ] Cross-platform behavior considered (CI builds Linux + Windows)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Include a `Closes #<issue>` line in the body if an issue exists.
+
+After PR creation:
+- Update `WORKFLOW_STATE.json` with `pr_url`
+- Report:
+
+```
+✓ Staging Complete
+  Branch:  <branch-name>
+  PR:      <pr-url>
+  Commit:  <type>(<scope>): <description>
+  Archive: .claude/workflow/archive/<work-slug>/
+```
+
+**Exit condition**: PR created. Update `WORKFLOW_STATE.json` to `stage: "review_gate"`.
+
+---
+
+## Stage 9: Review Gate
+
+**Entry condition**: `stage == "review_gate"`
+**Goal**: Wait for human review and approval of the PR
+
+### Process
+
+This is a **human gate**. The PR must be reviewed and approved by a human reviewer before it can merge.
+
+#### 9.1 Check PR Status
+
+```bash
+gh pr view <pr-number> --json state,reviewDecision,statusCheckRollup
+gh pr checks <pr-number>
+```
+
+CI runs `frontend-checks` (lint for `core/ui` and `friendshipper`), `build-linux`, and `build-windows`. Expect it to take a while; do not poll in a tight loop.
+
+#### 9.2 Review Options
+
+Before waiting for external review, present the user with their options:
+
+> **The PR is ready for review.** How would you like to proceed?
+
+1. **Run automated code review** — Invoke `/code-review` (or `/security-review` for auth/credential/network-facing changes) to analyze the changes before human review.
+2. **Check PR status** — View the current approval and CI status.
+3. **Monitor CI** — `gh pr checks <pr-number> --watch`.
+4. **Proceed to human review** — The PR is ready; reviewers can approve it on GitHub.
+
+#### 9.3 Status Reporting
+
+If the PR is **not yet approved**:
+
+```
+📍 Review Gate — Awaiting human approval
+   PR:     <pr-url>
+   Review: <pending/changes_requested/approved>
+   CI:     <passing/pending/failing>
+
+   The PR needs human review and approval before it can merge.
+```
+
+#### 9.4 Handling Failures
+
+If CI is **failing**:
+- Diagnose from the failing job's logs (`gh run view <run-id> --log-failed`)
+- Fix, then push additional commits (preserving review history) or re-run Stage 8 to re-squash if the user prefers a single commit
+- Re-check CI
+
+If review requested changes: return to Stage 6 or 7 as appropriate, then re-run Stage 8.
+
+If the PR **has been approved** and CI is passing:
+
+```
+✓ PR approved and CI passing — ready to merge.
+```
+
+The user merges from the GitHub PR UI (squash merge). Do not merge on their behalf unless they explicitly ask.
+
+**Exit condition**: PR approved and CI passing. Update state to `stage: "complete"`. After the merge lands, `/park` the worktree to return to a clean main.
+
+---
+
+## User Interaction Protocol
+
+### Before Every Stage Transition
+
+Unless `auto_advance` is `true` in `WORKFLOW_STATE.json`, present the user with:
+
+```
+📍 Current stage: <stage name>
+   <brief description of current state>
+
+⏭️  Next action: <stage name>
+   <description of what will happen>
+
+Proceed?
+```
+
+Options:
+- **Yes, proceed** — Execute the next stage
+- **Skip to stage...** — Jump to a specific stage (with warning about skipped steps)
+- **Enable auto-advance** — Stop asking for approval, just proceed (sets `auto_advance: true`)
+- **Describe in more detail** — Explain what the next stage involves before committing
+
+### When the User Returns After a Break
+
+```
+📍 Resuming Creation Workflow
+   Plan:    <plan document name>
+   Branch:  <branch name>
+   Stage:   <current stage> — <stage detail>
+   Last updated: <timestamp>
+
+What would you like to do?
+```
+
+Options:
+- **Continue where we left off** — Proceed with the detected next action
+- **Review current state** — Show the plan, progress, and any open issues
+- **Go back to stage...** — Return to an earlier stage for revision
+- **Abandon workflow** — Move the plan directory to `.claude/workflow/archive/<work-slug>-abandoned/` and `/park` the worktree
+
+---
+
+## Relationship to Other Instructions
+
+| Stage | Delegates To | Notes |
+|-------|-------------|-------|
+| 2A (Refine) | [RefineProposal.md](RefineProposal.md) | One of several refinement tools |
+| 5 (Sequencing) | [BreakDownWorkProposal.md](BreakDownWorkProposal.md) | Primary sequencing engine |
+| after merge | `/park` skill | Reset the worktree to latest main |
+
+Stages 1, 2B, 3, 4, 6, 7, 8, and 9 are defined entirely within this orchestrator.
+
+---
+
+## Error Handling
+
+- **WORKFLOW_STATE.json is corrupted or inconsistent**: Warn the user, offer to re-detect state via heuristics or start fresh
+- **Referenced files are missing**: Plan docs are untracked, so git history cannot recover them. Check `.claude/workflow/archive/` and ask the user before reconstructing anything
+- **State file belongs to another worktree**: Do not advance it. Tell the user which worktree owns it
+- **Branch has diverged from expected state**: Run `git -C <repo> log` to understand what happened. If commits exist that the workflow didn't create, ask the user about them
+- **Sub-agent fails during implementation**: Record the failure, try once more with additional context, then escalate to the user
+- **User wants to change the plan mid-implementation**: This is valid. Return to Stage 2A (Refine) with the understanding that completed implementation stages may need to be revisited. Update `WORKFLOW_STATE.json` accordingly
+
+---
+
+## Example: Full Workflow Execution
+
+### Invocation 1: Starting Fresh
+
+User is on `llm/<username>/ethos-parking-20260806` (a parking branch).
+
+```
+📍 No active Creation Workflow detected
+   Currently on parking branch: llm/<username>/ethos-parking-20260806
+
+Would you like to start a new Creation Workflow?
+```
+
+User: "Yes — I want Friendshipper to queue submits instead of dropping them when one is in flight."
+
+→ Execute Stage 1 (Plan): ask clarifying questions, research `friendshipper/src-tauri/src` and `core/src`, write `.claude/workflow/submit-queue/SUBMIT_QUEUE_PROPOSAL.md`, snapshot it, create branch `llm/<username>/submit-queue`, create `WORKFLOW_STATE.json`.
+
+### Invocation 2: Continuing After Planning
+
+State file shows `stage: "refine"`.
+
+```
+📍 Resuming Creation Workflow
+   Plan:    .claude/workflow/submit-queue/SUBMIT_QUEUE_PROPOSAL.md
+   Branch:  llm/<username>/submit-queue
+   Stage:   refine — Plan written, awaiting refinement
+
+⏭️  Next action: Refine
+   Present refinement options (automated review, diagram, direct feedback, etc.)
+
+Proceed?
+```
+
+### Invocation 3: Picking Up Mid-Implementation
+
+State file shows `stage: "implementing"`, `current_stage: "005"`.
+
+```
+📍 Resuming Creation Workflow
+   Stage:     implementing — Stage 005 (implement-queue-drain) in progress
+   Completed: 001, 002, 003, 004
+   Remaining: 005, 006, 007, 008
+
+⏭️  Next action: Continue implementing from Stage 005
+
+Proceed?
+```
+
+### Invocation 4: PR Approved
+
+```
+📍 Resuming Creation Workflow
+   Stage: review_gate — PR approved, CI passing
+   PR:    https://github.com/<owner>/ethos/pull/570
+
+✓ PR approved and CI passing — ready to merge.
+```
+
+→ Update state to `stage: "complete"`. The user squash-merges from the GitHub PR UI, then `/park` returns the worktree to a clean main.

--- a/.claude/instructions/RefineProposal.md
+++ b/.claude/instructions/RefineProposal.md
@@ -1,0 +1,239 @@
+<!-- claude-hint:
+model: opus
+effort: high
+rationale: Multi-turn Q&A review; cross-references source; deep architectural judgment
+-->
+
+Do not use instructions from this file unless asked.
+
+# Refine Proposal
+
+This instruction defines a review workflow for critically evaluating a work proposal document. The reviewer assumes the role of a senior engineer on a small team building cross-platform desktop developer tools in Rust (Tauri) and TypeScript (SvelteKit). Before producing the final review, the reviewer engages the author in a clarifying Q&A dialogue to build deep understanding of the proposal's intent, then produces a review document that reflects that understanding — including specific guidance on how the proposal could be updated to better communicate its goals.
+
+## Overview
+
+The workflow:
+- Reads and deeply analyzes an input proposal document (`$DOCUMENT`)
+- Evaluates it from the perspective of a senior engineer responsible for shipping and maintaining these tools
+- Asks the author targeted clarifying questions to resolve ambiguities and understand intent before forming judgments
+- Uses the author's answers to distinguish genuine gaps from merely unstated context
+- Produces a single structured review document with categorized feedback and concrete suggestions for strengthening the proposal
+
+## Prerequisites
+
+- The user must provide a `$DOCUMENT` path pointing to a proposal file (typically under `.claude/workflow/<work-slug>/`)
+- The repo source must be accessible for cross-referencing claims in the proposal
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `$DOCUMENT` | Yes | Path to the proposal document to review |
+
+## Reviewer Persona
+
+**Role**: Senior engineer, cross-platform desktop tooling
+**Experience**: Deep Rust (async/tokio, error handling, process orchestration), Tauri command/IPC design, SvelteKit + TypeScript frontends, and the git/git-LFS behavior these tools automate
+**Disposition**: Constructively critical. The goal is to make the proposal succeed, not to tear it down. Every question should help the author think more clearly about implementation.
+
+**Review priorities** (in order):
+1. **Correctness**: Will this actually work as described? Are the technical claims accurate?
+2. **Completeness**: What's missing that would block implementation? What decisions are deferred that shouldn't be?
+3. **Clarity**: Could two engineers read this and arrive at different implementations?
+4. **Risk**: What are the highest-risk elements, and are they acknowledged? These tools operate on users' real repositories — data-loss risk deserves special weight.
+5. **Integration**: How does this interact with existing systems? Are there hidden coupling or dependency issues, especially across the `ethos-core` / app boundary?
+
+## Steps
+
+### 1. Read the Proposal
+
+1. Read the full contents of `$DOCUMENT`
+2. Take note of the proposal's stated goals, scope, architecture, and any open questions it already identifies
+3. Form an initial list of areas that are unclear, ambiguous, or that you need more context to evaluate
+
+### 2. Cross-Reference Against Source Code
+
+Investigate claims made in the proposal by searching the repo:
+
+1. **Verify referenced systems exist**: If the proposal mentions extending or integrating with existing modules, types, Tauri commands, or Svelte components, confirm they exist and understand their current interfaces
+2. **Check both sides of the boundary**: For anything user-visible, trace Svelte component → `invoke(...)` → `#[tauri::command]` handler → `ethos-core` operation. Proposals frequently describe one side and leave the other implicit
+3. **Check for conflicting patterns**: Look for existing code that solves similar problems differently, which could indicate a consistency issue or missed prior art
+4. **Check shared-code blast radius**: `core/` is consumed by the `friendshipper` app and `friendshipper/server`, and `core/ui/` by the app frontend. Determine whether the proposal accounts for every consumer, not just the one it names
+5. **Identify touched surface area**: Determine which crates, modules, components, and config types the proposal would need to modify or depend on
+6. **Note what the source code makes clear**: Some questions that seem ambiguous in the proposal may be easily answered by reading the code. Filter these out — they are not worth raising to the author
+
+Do NOT exhaustively audit the entire codebase. Focus investigation on systems the proposal directly references or would need to interact with.
+
+### 3. Cross-Reference Against Dependency Behavior
+
+If the proposal makes claims about crate, Tauri, Svelte, or git/LFS behavior:
+
+1. Verify the claim against the **version actually pinned** in `Cargo.toml` / `package.json` — this matters most for Tauri (v2 APIs differ substantially from v1) and SvelteKit
+2. Use `WebFetch`/`WebSearch` against docs.rs or upstream documentation for API-level claims rather than assuming
+3. For git and git-LFS behavior claims, prefer verifying against the repo's own wrapper code, which encodes hard-won behavior, over general git knowledge
+
+Only investigate when the proposal makes specific technical claims. Do not speculatively audit dependencies.
+
+### 4. Ask Clarifying Questions
+
+Before forming the final review, engage the author in a dialogue to resolve ambiguities and deepen understanding. This is the core iterative step — it prevents the review from raising questions the author already has answers to.
+
+#### 4.1. Formulate Questions
+
+From Steps 1-3, identify questions where the author's answer would materially change the review. Good clarifying questions:
+- Resolve ambiguity about intent ("Does this mean X or Y?")
+- Surface unstated context the author may be carrying ("What's the expected scale/frequency of Z?")
+- Probe design rationale ("Why X over Y? Is there a constraint I'm not seeing?")
+- Verify understanding ("I'm reading this as [paraphrase]. Is that accurate?")
+
+Do NOT ask questions that:
+- Are already answered in the document
+- Can be answered by reading the source code (you already did that in Steps 2-3)
+- Are rhetorical or argumentative
+- Are about minor wording choices
+
+#### 4.2. Present Questions to the Author
+
+Ask the author your clarifying questions. Group them by topic area for readability. Aim for the minimum number of questions needed to meaningfully improve the review — typically 3-8 questions per round.
+
+Use `AskUserQuestion` when questions have clear enumerable options. Use conversational text when questions are open-ended.
+
+#### 4.3. Incorporate Answers
+
+After the author responds:
+1. Update your understanding of the proposal based on their answers
+2. Determine if any answers reveal new areas that need follow-up questions
+3. If significant new ambiguities surfaced, ask a second (shorter) round of follow-up questions. Avoid more than 2-3 total question rounds — the goal is understanding, not interrogation
+4. Note cases where the author's answer reveals that the proposal document doesn't adequately communicate the intent. These become suggestions for improving the document
+
+### 5. Generate the Review
+
+Produce a structured review document organized into the following sections. Each item should be a specific, actionable question or observation — not vague commentary.
+
+#### Review Document Structure
+
+```markdown
+# Review: <Proposal Title>
+
+**Document**: <$DOCUMENT path>
+**Reviewer**: Senior engineer, desktop tooling (AI-assisted)
+**Date**: <current date>
+
+---
+
+## Critical Issues
+
+Items that would likely block or derail implementation if not addressed.
+Each item should explain WHY it's critical and WHAT information is needed.
+
+- **[C1]** <Title>
+  <Detailed question or observation. Reference specific sections of the proposal.>
+
+## Design Questions
+
+Architectural or design decisions that are ambiguous, unstated, or could reasonably go multiple ways. These are questions where the answer materially affects implementation.
+
+- **[D1]** <Title>
+  <Question with context about why the answer matters.>
+
+## Consistency Issues
+
+Places where the proposal contradicts itself, contradicts existing code patterns, or makes incompatible claims.
+
+- **[I1]** <Title>
+  <Description of the inconsistency with references to both sides.>
+
+## Unstated Assumptions
+
+Things the proposal assumes to be true but does not explicitly state. Particularly dangerous when they involve the Rust/TypeScript boundary, `ethos-core` consumers other than the app in question, or the state of a user's local repository.
+
+- **[A1]** <Title>
+  <The assumption, why it might not hold, and what happens if it doesn't.>
+
+## Cross-Platform & Repo-Safety Concerns
+
+CI builds Linux and Windows, and these tools mutate real user repositories. Path handling, process spawning, file locking, line endings, interrupted operations, and anything that could lose uncommitted or unpushed work deserve special attention.
+
+- **[P1]** <Title>
+  <Concern with explanation of the platform or data-safety implications.>
+
+## Scope & Risk
+
+Observations about scope creep, underestimated complexity, or high-risk elements that deserve explicit mitigation plans. New dependencies belong here.
+
+- **[R1]** <Title>
+  <Risk description and suggested mitigation or question.>
+
+## Minor Clarifications
+
+Lower-priority items that would improve the proposal but are not blocking.
+
+- **[M1]** <Title>
+  <Suggestion or question.>
+
+---
+
+## Suggested Document Updates
+
+Specific recommendations for how the proposal document itself could be improved to better communicate the author's intent. These are informed by the clarifying Q&A — places where the author had a good answer that simply wasn't captured in the document.
+
+- **[U1]** <Section or area to update>
+  <What to add, clarify, or restructure, and why it would help a reader.>
+
+---
+
+## Summary
+
+<2-3 sentence overall assessment: what's strong about the proposal, the single most important thing to address, and a general confidence level in the proposal's implementability.>
+```
+
+#### Review Quality Guidelines
+
+- **Be specific**: "How does X handle Y when Z?" is better than "X needs more detail"
+- **Reference the proposal**: Quote or cite the specific section being questioned
+- **Explain the stakes**: For each question, briefly explain what goes wrong if the answer is wrong or missing
+- **Distinguish what you know from what you're asking**: If you verified something in the source, say so. If you couldn't find evidence either way, say that too
+- **Don't pad**: If a section has no items, include it with "None identified." Do not fabricate concerns to fill sections
+- **Prioritize within sections**: List the most important items first
+
+### 6. Write the Review Document
+
+1. Determine the output path:
+   - Place the review file adjacent to the input document (same plan directory)
+   - Name format: `<document-basename>_REVIEW.md`
+   - If a file with this name already exists, confirm with the user before overwriting
+2. Write the review document
+3. Display a summary to the user:
+   ```
+   Review complete
+     Document: <$DOCUMENT>
+     Review:   <output-path>
+
+     Critical issues:       <count>
+     Design questions:      <count>
+     Consistency issues:    <count>
+     Assumptions:           <count>
+     Cross-platform/safety: <count>
+     Scope/Risk:            <count>
+     Minor:                 <count>
+     Document updates:      <count>
+     Total items:           <count>
+   ```
+
+## Error Handling
+
+- **$DOCUMENT not found**: Exit with error, ask user to verify the path
+- **$DOCUMENT is empty or unreadable**: Exit with error
+- **Source code not accessible**: Warn that cross-referencing is limited, proceed with proposal-only review
+- **Dependency docs unreachable (offline)**: Warn that API claims cannot be verified, flag them as unverified assumptions
+- **Author unresponsive to clarifying questions**: Proceed with the review based on available information, noting which items would benefit from author clarification
+- **Output path not writable**: Ask user for an alternative output location
+
+## Important Notes
+
+- **Do not rewrite the proposal**: The output is a review document with questions and observations, not an edited version of the original. The author retains full ownership of the proposal
+- **Filter out code-answerable questions**: If a question can be definitively answered by reading the source, answer it yourself rather than raising it. Only raise questions that require human judgment, domain knowledge, or design decisions
+- **Respect the author's intent**: The goal is to strengthen the proposal, not redirect it. If you disagree with a fundamental design choice, frame it as a risk with alternatives, not as a directive
+- **Every consumer is in scope for shared code**: Any proposal touching `core/` or `core/ui/` should be evaluated against all of its consumers (the app, its frontend, and the server), even if it names only one
+- **Repo safety is always relevant**: These tools run destructive git operations on users' working copies. Evaluate every proposal for what happens on interruption, conflict, or unexpected repo state
+- **Don't assume the proposal is wrong**: A question is not an accusation. Many items may have good answers the author simply didn't include. Frame feedback as "this isn't addressed" rather than "this is wrong"

--- a/.claude/scripts/Reset-WorktreeToMain.ps1
+++ b/.claude/scripts/Reset-WorktreeToMain.ps1
@@ -1,0 +1,305 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Resets a worktree to the latest main branch for starting fresh work.
+
+.DESCRIPTION
+    Parks the current branch locally (never pushed) to free up worktree state,
+    then resets the worktree to the latest origin/main. Parking branches exist
+    solely to satisfy git worktree branch uniqueness requirements and contain
+    only commits already in main.
+
+    Safe to run concurrently from multiple worktrees of the same repo -- git
+    operations retry with exponential backoff on lock contention.
+
+.PARAMETER Force
+    Skip the uncommitted changes check and reset anyway. Before resetting, ALL
+    staged, unstaged, and untracked changes are saved to a git stash so work can
+    never be completely lost. The stash ref is printed and can be recovered with
+    `git stash apply`.
+
+.EXAMPLE
+    .\Reset-WorktreeToMain.ps1
+    Resets the worktree to main, aborting if there are uncommitted changes.
+
+.EXAMPLE
+    .\Reset-WorktreeToMain.ps1 -Force
+    Stashes any staged/uncommitted/untracked changes, then resets to main.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [Alias("f")]
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+#region Helper Functions
+
+function Invoke-Git {
+    <#
+    .SYNOPSIS
+        Runs a git command, suppressing stderr from triggering PowerShell errors.
+    .DESCRIPTION
+        Git writes informational output to stderr (e.g. fetch progress), which
+        ErrorActionPreference=Stop treats as terminating errors. This helper
+        temporarily sets Continue to capture all output, then checks LASTEXITCODE.
+    .OUTPUTS
+        Hashtable with Output (string) and ExitCode (int).
+    #>
+    param([Parameter(Mandatory)][string]$Arguments)
+
+    $prevPref = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $output = Invoke-Expression "git $Arguments 2>&1" | Out-String
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $prevPref
+
+    return @{
+        Output   = $output.Trim()
+        ExitCode = $exitCode
+    }
+}
+
+function Invoke-GitWithRetry {
+    <#
+    .SYNOPSIS
+        Runs a git command with automatic retry on lock contention.
+    .DESCRIPTION
+        Worktrees share a .git directory, so concurrent operations can fail with
+        "Unable to create '...lock': File exists". This retries with exponential
+        backoff so multiple worktrees can run this script in parallel.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Arguments,
+        [int]$MaxRetries = 5,
+        [int]$BaseDelayMs = 500
+    )
+
+    for ($attempt = 0; $attempt -le $MaxRetries; $attempt++) {
+        $result = Invoke-Git $Arguments
+        if ($result.ExitCode -eq 0) {
+            return $result
+        }
+
+        $isLockError = $result.Output -match "Unable to create.*\.lock" -or
+                       $result.Output -match "index\.lock" -or
+                       $result.Output -match "Cannot lock ref"
+
+        if (-not $isLockError -or $attempt -eq $MaxRetries) {
+            return $result
+        }
+
+        $delay = $BaseDelayMs * [Math]::Pow(2, $attempt)
+        # Add jitter to avoid thundering herd
+        $jitter = Get-Random -Minimum 0 -Maximum ($delay * 0.5)
+        $totalDelay = [int]($delay + $jitter)
+        Write-Host "  Lock contention detected, retrying in $($totalDelay)ms (attempt $($attempt + 1)/$MaxRetries)..." -ForegroundColor Yellow
+        Start-Sleep -Milliseconds $totalDelay
+    }
+}
+
+function Get-RepoRoot {
+    $result = Invoke-Git "rev-parse --show-toplevel"
+    if ($result.ExitCode -ne 0) {
+        return $null
+    }
+    return $result.Output
+}
+
+function Get-GitUsername {
+    <#
+    .SYNOPSIS
+        Returns the username portion of the configured git email.
+    #>
+    $result = Invoke-Git "config user.email"
+    if ($result.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($result.Output)) {
+        throw "Git user.email is not configured. Run: git config user.email <your-email>"
+    }
+    if ($result.Output -match "^([^@]+)@") {
+        return $Matches[1].ToLower()
+    }
+    throw "Could not parse a username from git user.email: $($result.Output)"
+}
+
+function Test-UncommittedChanges {
+    $result = Invoke-Git "status --porcelain"
+    if ($result.ExitCode -ne 0) {
+        throw "Failed to check git status: $($result.Output)"
+    }
+    return -not [string]::IsNullOrWhiteSpace($result.Output)
+}
+
+#endregion
+
+#region Main Script
+
+# Step 1: Pre-flight checks
+$repoRoot = Get-RepoRoot
+if (-not $repoRoot) {
+    Write-Error "Not a git repository. Please run from within a git repository."
+    exit 1
+}
+
+Push-Location $repoRoot
+try {
+    $gitUser = Get-GitUsername
+    # Worktree name is the leaf of the worktree root, so parking branches from
+    # different worktrees never collide (e.g. ethos, alpha, bravo).
+    $worktreeName = (Split-Path -Leaf $repoRoot).ToLower()
+
+    $result = Invoke-Git "rev-parse --abbrev-ref HEAD"
+    if ($result.ExitCode -ne 0) {
+        Write-Error "Failed to determine current branch: $($result.Output)"
+        exit 1
+    }
+    $currentBranch = $result.Output
+
+    Write-Host "Current branch: $currentBranch" -ForegroundColor Gray
+    Write-Host "Git user: $gitUser" -ForegroundColor Gray
+    Write-Host "Worktree: $worktreeName ($repoRoot)" -ForegroundColor Gray
+    Write-Host ""
+
+    $stashRef = $null
+    if (Test-UncommittedChanges) {
+        if ($Force) {
+            # ALWAYS stash before a forced reset so working-tree work can never be
+            # completely lost. --include-untracked captures staged, unstaged, AND
+            # untracked files. Worktrees share the .git dir, so the stash is
+            # recoverable from any worktree via `git stash list` / `git stash apply`.
+            $stashMessage = "Reset-WorktreeToMain auto-stash: $worktreeName ($currentBranch) $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+            Write-Host "Stashing staged/uncommitted/untracked changes before reset (-Force)..." -ForegroundColor Cyan
+            $stashResult = Invoke-GitWithRetry "stash push --include-untracked --message `"$stashMessage`""
+            if ($stashResult.ExitCode -ne 0) {
+                Write-Error "Failed to stash uncommitted changes; aborting to avoid losing work:`n$($stashResult.Output)"
+                exit 1
+            }
+            # Capture the stash ref (newest entry) so we can report it for recovery.
+            $stashListResult = Invoke-Git "stash list --format=`"%gd: %gs`" -1"
+            $stashRef = if ($stashListResult.ExitCode -eq 0) { $stashListResult.Output } else { "stash@{0}" }
+            Write-Host "  Saved to: $stashRef" -ForegroundColor Green
+        } else {
+            Write-Error "Uncommitted changes detected. Commit or stash changes before resetting, or use -Force to stash and discard."
+            exit 1
+        }
+    }
+
+    # Check for unpushed commits not in main that would be lost
+    $result = Invoke-Git "log origin/main..HEAD --oneline"
+    if ($result.ExitCode -ne 0) {
+        # origin/main may not exist yet; fetch first and recheck after
+        Write-Host "Could not compare with origin/main, will check after fetch." -ForegroundColor Yellow
+    } elseif (-not [string]::IsNullOrWhiteSpace($result.Output)) {
+        # There are commits not in main -- check if they've been pushed to the remote tracking branch
+        $trackingResult = Invoke-Git "rev-parse --abbrev-ref --symbolic-full-name `"@{upstream}`""
+        if ($trackingResult.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($trackingResult.Output)) {
+            # No upstream configured -- all commits are unpushed
+            $unpushedOutput = $result.Output
+        } else {
+            $upstream = $trackingResult.Output
+            $unpushedResult = Invoke-Git "log $upstream..HEAD --oneline"
+            $unpushedOutput = if ($unpushedResult.ExitCode -eq 0) { $unpushedResult.Output } else { $result.Output }
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($unpushedOutput)) {
+            # Check if these commits were already merged to main (e.g., squash-merged via PR
+            # and the remote branch deleted). The commits appear "unpushed" because the local
+            # SHA differs from the squash-merge commit on main, but the content is already there.
+            $alreadyMerged = $false
+            $lsRemoteResult = Invoke-Git "ls-remote --heads origin `"$currentBranch`""
+            $remoteBranchExists = $lsRemoteResult.ExitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($lsRemoteResult.Output)
+
+            if (-not $remoteBranchExists) {
+                # Remote branch is gone -- use git cherry to check if patch content is in main.
+                # git cherry compares patch-ids (diff content), so it detects squash-merged
+                # commits even though the SHAs differ.
+                $cherryResult = Invoke-Git "cherry origin/main HEAD"
+                if ($cherryResult.ExitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($cherryResult.Output)) {
+                    $unmergedCommits = ($cherryResult.Output -split "`n") | Where-Object { $_.TrimStart().StartsWith("+") }
+                    if (-not $unmergedCommits) {
+                        $alreadyMerged = $true
+                    }
+                }
+            }
+
+            if ($alreadyMerged) {
+                Write-Host "Local commits already merged to main (remote branch deleted). Safe to reset." -ForegroundColor Green
+            } else {
+                $commitCount = ($unpushedOutput -split "`n").Count
+                if ($Force) {
+                    Write-Host "WARNING: $commitCount unpushed commit(s) will be discarded (-Force):" -ForegroundColor Yellow
+                    Write-Host $unpushedOutput -ForegroundColor Yellow
+                } else {
+                    Write-Error "Branch has $commitCount unpushed commit(s) that would be lost:`n$unpushedOutput`nPush the branch first to preserve the work, or use -Force to discard."
+                    exit 1
+                }
+            }
+        }
+    }
+
+    # Step 2: Fetch latest main
+    Write-Host "Fetching latest main from origin..." -ForegroundColor Cyan
+    $result = Invoke-GitWithRetry "fetch origin main"
+    if ($result.ExitCode -ne 0) {
+        Write-Error "Failed to fetch origin/main. You may be offline or the remote is unavailable.`n$($result.Output)"
+        exit 1
+    }
+
+    # Step 3: Create parking branch at origin/main and switch to it (single atomic operation).
+    # Using `switch -C` instead of separate `checkout -B` + `reset --hard` to minimize
+    # lock contention when multiple worktrees run this script concurrently.
+    $dateStamp = Get-Date -Format "yyyyMMdd"
+    $parkingBranch = "llm/$gitUser/$worktreeName-parking-$dateStamp"
+
+    Write-Host "Switching to parking branch at origin/main: $parkingBranch" -ForegroundColor Cyan
+    $switchArgs = "switch -C `"$parkingBranch`" origin/main --discard-changes"
+    $result = Invoke-GitWithRetry $switchArgs
+    if ($result.ExitCode -ne 0) {
+        Write-Error "Failed to switch to parking branch at origin/main: $($result.Output)"
+        exit 1
+    }
+
+    # Step 4: Rebuild untracked cache.
+    # The untracked cache (core.untrackedCache) can go stale after branch switches,
+    # causing ghost untracked files and "could not open directory" warnings.
+    Write-Host "Rebuilding untracked cache..." -ForegroundColor Cyan
+    $result = Invoke-Git "update-index --force-untracked-cache"
+    if ($result.ExitCode -ne 0) {
+        Write-Host "WARNING: Failed to rebuild untracked cache: $($result.Output)" -ForegroundColor Yellow
+    }
+
+    # Step 5: Verify state
+    $result = Invoke-Git "log -1 --oneline"
+    if ($result.ExitCode -ne 0) {
+        Write-Error "Failed to verify HEAD commit: $($result.Output)"
+        exit 1
+    }
+    $headCommit = $result.Output
+
+    if (Test-UncommittedChanges) {
+        Write-Host "WARNING: Unexpected uncommitted changes after reset." -ForegroundColor Yellow
+    }
+
+    # Step 6: Output results
+    Write-Host ""
+    Write-Host "Worktree reset to main" -ForegroundColor Green
+    Write-Host "  Parking branch: $parkingBranch (local only, do not push)" -ForegroundColor Gray
+    Write-Host "  Now at: $headCommit" -ForegroundColor Gray
+    if ($stashRef) {
+        Write-Host "  Stashed work: $stashRef" -ForegroundColor Gray
+        Write-Host "  Recover with: git stash apply `"$($stashRef.Split(':')[0])`"" -ForegroundColor Gray
+    }
+    Write-Host "  Ready for new work" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "  Note: switching branches can invalidate build state. If the frontend" -ForegroundColor DarkGray
+    Write-Host "  was built from another branch, re-run 'yarn' / 'yarn package' as needed." -ForegroundColor DarkGray
+
+    exit 0
+} finally {
+    Pop-Location
+}
+
+#endregion

--- a/.claude/skills/park/SKILL.md
+++ b/.claude/skills/park/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: park
+description: Reset the current worktree to latest main, parking the current branch
+allowed-tools: Bash, PowerShell
+model: haiku
+effort: low
+---
+
+# Park Worktree (Reset to Main)
+
+Reset the current worktree to the latest `origin/main`, parking the current branch locally.
+
+All paths are relative to the **repo root** (the directory containing the workspace `Cargo.toml`).
+
+## Steps
+
+1. First, check for uncommitted changes by running: `git status --porcelain`
+   - If there are uncommitted changes, display them clearly to the user and **stop**. Do NOT pass `-Force`. Ask the user what they want to do (commit, stash, or discard).
+2. Check for unpushed commits: `git log origin/main..HEAD --oneline`
+   - If there are unpushed commits, display them and **stop**. Ask the user if they want to push first or discard.
+   - Exception: if the branch's remote is gone and `git cherry origin/main HEAD` shows no `+` commits, the work was already squash-merged and is safe to discard. The script detects this case itself.
+3. Only once the working tree is clean and there are no unpushed commits (or the user has confirmed), run the script from the repo root:
+   - Windows: `powershell -NoProfile -ExecutionPolicy Bypass -File ".\.claude\scripts\Reset-WorktreeToMain.ps1" $ARGUMENTS`
+   - macOS/Linux (PowerShell 7): `pwsh -NoProfile -File ./.claude/scripts/Reset-WorktreeToMain.ps1 $ARGUMENTS`
+   - If PowerShell is unavailable, perform the equivalent steps by hand: `git fetch origin main`, then `git switch -C <parking-branch> origin/main --discard-changes` using the naming convention below.
+4. Report the result — new parking branch name and current HEAD commit.
+
+## Arguments
+
+- `-Force` — Skip safety checks and discard all local changes (only pass if the user explicitly asks). Working-tree changes are always stashed first, and the stash ref is reported.
+
+## Conventions
+
+- **Parking branches**: `llm/<git-username>/<worktree-name>-parking-<YYYYMMDD>`, where `<git-username>` is the local part of `git config user.email` and `<worktree-name>` is the leaf directory of the worktree root. These branches are **local only — never push them**. They exist so git worktrees always hold a unique branch, and they only ever contain commits already in `main`.
+- **Worktrees**: main checkout at `<repos>/ethos`, additional worktrees at `<repos>/ethos-worktrees/<name>` using short fixed names (`alpha`, `bravo`, `charlie`, `echo`). Because the parking branch embeds the worktree name, every worktree parks to its own branch and several can park concurrently.
+- See `.claude/README.md` for the full branch/worktree conventions.
+
+## Notes
+
+- Worktrees do not share `target/` or `node_modules/`. After parking, a stale frontend build can linger; re-run `yarn` and `yarn package` in `core/ui` if the next task touches the UI.

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: workflow
+description: Advance the Creation Workflow — detect current stage and execute the next step (plan, refine, fracture, singletonize, loss check, sequence, implement, test, stage, review)
+allowed-tools: Bash, PowerShell, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, Skill, WebFetch, WebSearch
+model: opus
+effort: max
+---
+
+# Creation Workflow
+
+Invoke the Creation Workflow orchestrator defined in `.claude/instructions/DoNextWorkflowStep.md`.
+
+Read and follow that document fully — it defines all stages, state detection, and execution logic.
+
+## Steps
+
+1. Read `.claude/instructions/DoNextWorkflowStep.md`
+2. Follow its **Invocation protocol**: detect current stage, describe next action, wait for approval, execute, update state, report

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,10 @@ node_modules
 .DS_Store
 
 Claude.md
-.claude
+
+# claude code: shared agent tooling is tracked, per-user state is not
+.claude/*
+!.claude/README.md
+!.claude/instructions/
+!.claude/scripts/
+!.claude/skills/

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -146,10 +146,7 @@ async fn filter_to_textlike_paths(
         .split(|&b| b == 0)
         .filter(|s| !s.is_empty())
         .collect();
-    for record in fields.chunks_exact(3) {
-        let [path, attr, value] = record else {
-            unreachable!("chunks_exact(3) yields 3-element slices");
-        };
+    for [path, attr, value] in fields.as_chunks::<3>().0 {
         let attr = std::str::from_utf8(attr).unwrap_or("");
         let value = std::str::from_utf8(value).unwrap_or("");
         let exclude = (attr == "filter" && value == "lfs") || (attr == "text" && value == "unset");

--- a/friendshipper/src-tauri/src/system/unreal.rs
+++ b/friendshipper/src-tauri/src/system/unreal.rs
@@ -32,8 +32,10 @@ pub fn update_engine_association_registry(
                 // need to do this annoying conversion from a null-terminated u16 byte array to String
                 let widechars: Vec<u16> = value
                     .bytes
-                    .chunks_exact(2)
-                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|&chunk| u16::from_le_bytes(chunk))
                     .collect();
 
                 let null_byte_index = widechars


### PR DESCRIPTION
## Summary

Adds optional [Claude Code](https://claude.com/claude-code) tooling under `.claude/`. Nothing here is required to build, test, or contribute — the normal `cargo` and `yarn` workflows are untouched.

- **`/park`** — resets a worktree to latest `origin/main`, parking the current branch on a local-only branch. It refuses to discard uncommitted changes or unpushed commits, always stashes before a forced reset (and prints the stash ref), detects branches that were already squash-merged via `git cherry`, and retries on git lock contention so several worktrees can park concurrently.
- **`/workflow`** — advances a 10-step workflow: plan → refine → fracture → singletonize → loss check → sequence → implement → test → stage → review gate. It delegates proposal review and work breakdown to two instruction documents.

The instruction docs encode this repo's actual conventions so an agent doesn't have to guess: the workspace layout, the CI-equivalent commands, the `pre-commit`/`commit-msg` hooks (including that the hook's nightly workspace clippy is stricter than CI), the commitlint type/scope enums, and a branch convention that prefixes agent-driven branches with `llm/` to keep them distinguishable from human ones.

## `.gitignore` change

`.claude` was ignored wholesale. It now ignores `.claude/*` and re-includes only the four shared paths:

```
.claude/*
!.claude/README.md
!.claude/instructions/
!.claude/scripts/
!.claude/skills/
```

So the shared tooling is tracked while per-user state — `.claude/workflow/` (in-progress plan documents and workflow state) and `settings.local.json` — stays ignored. Verified both directions with `git check-ignore`.

## Unrelated lint fix, included because it blocked committing

Two `chunks_exact` calls are rewritten to `as_chunks`:

- `friendshipper/src-tauri/src/repo/operations/gh/submit.rs`
- `friendshipper/src-tauri/src/system/unreal.rs`

Recent nightly clippy added `chunks_exact_to_as_chunks`, and the `pre-commit` hook runs `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`, so this lint blocked **every** local commit regardless of what was being staged. Both rewrites drop the trailing remainder exactly as `chunks_exact` did, so behavior is unchanged; in `submit.rs` the fixed-size array pattern is now infallible, so its `unreachable!` arm is gone.

Worth noting separately: because the hook pins `+nightly` with `-D warnings` and there is no toolchain file, any new nightly lint becomes a commit blocker for everyone, while a nightly older than the dependency floor (currently rustc 1.91.1) fails to build at all. That's a narrow window, and it may be worth pinning a toolchain.

## Test plan

Verified locally on Windows, capturing each command's own exit code:

- [x] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` (the hook's check) — clean
- [x] `cargo clippy --all-features -p ethos-core -- -D warnings` — clean
- [x] `cargo clippy --all-features -p friendshipper -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p ethos-core` — 34 passed, 5 ignored
- [x] `cargo test --bin friendshipper` — passed
- [x] `/park`'s safety path exercised: it correctly refused to run against a dirty tree

Not verified locally, flagged honestly:

- The `submit.rs` path has no test covering it, so that rewrite rests on the compiler and on `as_chunks().0` being equivalent to `chunks_exact` — not on an exercised test.
- `unreal.rs` is Windows-only, so Linux CI won't compile that hunk.
- `as_chunks` requires rustc >= 1.88; CI resolves `stable`, which is well past that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
