### PR TITLE
feat(friendshipper): block configured file globs per target branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run unit tests
         run: |
           cargo test --verbose --release -p ethos-core
-          cargo test --verbose --release --bin ${{ matrix.app }}
+          cargo test --verbose --release --lib --bins -p ${{ matrix.app }}
 
       - name: Build core ui
         run: |
@@ -156,7 +156,7 @@ jobs:
       - name: Run unit tests
         run: |
           cargo test --verbose --release -p ethos-core
-          cargo test --verbose --release --bin ${{ matrix.app }}
+          cargo test --verbose --release --lib --bins -p ${{ matrix.app }}
 
       - name: Build core ui
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +2536,7 @@ dependencies = [
  "directories-next",
  "ethos-types",
  "futures",
+ "globset",
  "graphql_client",
  "hex",
  "http 0.2.12",
@@ -3345,6 +3356,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 config = "0.13.3"
 directories-next = "2.0.0"
+globset = "0.4"
 keyring = "2"
 lazy_static = { version = "1.4.0", features = [] }
 log = "0.4.20"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ axum = { workspace = true }
 chrono = { workspace = true }
 config = { workspace = true }
 directories-next = { workspace = true }
+globset = { workspace = true }
 keyring = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/core/src/blocked_files.rs
+++ b/core/src/blocked_files.rs
@@ -1,0 +1,462 @@
+use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
+
+/// Compiles and matches `blockedFileGlobs` patterns from `friendshipper.yaml`
+/// against repo-relative, forward-slash-separated paths.
+///
+/// This module is a pure matching primitive: it does no logging itself
+/// (callers log `invalid`/`warnings` — the config-load path is the only one
+/// that does, since the on-demand compile used by `StatusOp` runs on every
+/// status refresh and would otherwise spam the log continuously), and it has
+/// no opinion about `FileState::Deleted`. A file whose state is `Deleted`
+/// must never be blocked — removing a wrongly-committed asset is the
+/// cleanup path this feature exists to preserve — so callers must filter out
+/// deleted files before calling `is_blocked`.
+pub struct BlockedFileMatcher(GlobSet);
+
+/// Result of compiling a project's `blockedFileGlobs` list.
+pub struct BlockedFileMatcherResult {
+    pub matcher: BlockedFileMatcher,
+    /// (pattern, error message) for patterns that failed to compile.
+    pub invalid: Vec<(String, String)>,
+    /// (pattern, warning message) for patterns that will silently under-match.
+    pub warnings: Vec<(String, String)>,
+}
+
+impl BlockedFileMatcher {
+    /// Compile `patterns` into a matcher. Never fails: invalid patterns are
+    /// collected in `invalid` and excluded from the matcher.
+    ///
+    /// Named `compile` rather than `new` because it returns
+    /// `BlockedFileMatcherResult` — bundling the matcher with per-pattern
+    /// diagnostics — rather than `Self`.
+    pub fn compile(patterns: &[String]) -> BlockedFileMatcherResult {
+        let mut builder = GlobSetBuilder::new();
+        let mut invalid: Vec<(String, String)> = Vec::new();
+        let mut warnings: Vec<(String, String)> = Vec::new();
+
+        for pattern in patterns {
+            let glob: Result<Glob, _> = GlobBuilder::new(pattern)
+                .case_insensitive(true)
+                .literal_separator(true)
+                .backslash_escape(false)
+                .build();
+
+            match glob {
+                Ok(glob) => {
+                    if pattern.contains('\\') {
+                        // A Windows-style pattern like `Content\Characters\**`
+                        // compiles without error and doesn't trip the
+                        // under-match check below (it does contain `**`), but
+                        // it is platform-inconsistent in a way that is easy to
+                        // miss: globset's own parser normalizes a `\` in the
+                        // *pattern* to `/` whenever `std::path::is_separator`
+                        // considers `\` a separator on the compiling platform
+                        // — true on Windows, false on Unix — regardless of
+                        // this module's own `backslash_escape(false)` setting,
+                        // which only controls escape semantics, not this
+                        // separator normalization. So on Windows the pattern
+                        // is silently rewritten to `Content/Characters/**`
+                        // and happens to match correctly; on Linux/macOS `\`
+                        // stays a literal character, and since a real
+                        // repo-relative path is always forward-slash (per
+                        // this module's contract), the pattern matches
+                        // nothing there. A project author who authors and
+                        // tests `friendshipper.yaml` on Windows would never
+                        // see this fail — only their Linux/macOS teammates'
+                        // submits would silently go unprotected. Warn
+                        // unconditionally on any backslash in the pattern
+                        // rather than rely on that platform difference.
+                        warnings.push((
+                            pattern.clone(),
+                            format!(
+                                "pattern `{pattern}` contains a backslash (`\\`); \
+                                 blockedFileGlobs patterns must use forward slashes (`/`) as the \
+                                 path separator. Whether a backslash acts as a directory \
+                                 separator here depends on the platform compiling this pattern, \
+                                 so the same friendshipper.yaml can protect assets on Windows \
+                                 while silently protecting nothing on Linux/macOS. Did you mean \
+                                 `{}`?",
+                                pattern.replace('\\', "/")
+                            ),
+                        ));
+                    }
+
+                    if !pattern.contains('/') && !pattern.contains("**") {
+                        warnings.push((
+                            pattern.clone(),
+                            format!(
+                                "pattern `{pattern}` contains neither `/` nor `**`; because \
+                                 matching uses literal_separator semantics, this will only match \
+                                 a file named exactly `{pattern}` at the repository root, not in \
+                                 any subdirectory. This likely does not do what you intend — did \
+                                 you mean `**/{pattern}`?"
+                            ),
+                        ));
+                    }
+                    builder.add(glob);
+                }
+                Err(e) => {
+                    invalid.push((pattern.clone(), e.to_string()));
+                }
+            }
+        }
+
+        let matcher = match builder.build() {
+            Ok(set) => BlockedFileMatcher(set),
+            Err(e) => {
+                // Building a GlobSet from already-individually-valid Globs is
+                // not expected to fail in practice, but GlobSetBuilder::build
+                // is fallible, and this function's contract is "never fails,
+                // never panics" — so degrade to an empty matcher rather than
+                // unwrap. This drops every pattern that made it past the loop
+                // above, which is the fail-safe direction: a bad or missing
+                // block on submitted files is a lesser failure than bricking
+                // app startup for every user of the project.
+                invalid.push((
+                    "<all patterns>".to_string(),
+                    format!("failed to build combined glob set: {e}"),
+                ));
+                BlockedFileMatcher::empty()
+            }
+        };
+
+        BlockedFileMatcherResult {
+            matcher,
+            invalid,
+            warnings,
+        }
+    }
+
+    /// A matcher that matches nothing.
+    pub fn empty() -> Self {
+        BlockedFileMatcher(GlobSet::empty())
+    }
+
+    /// `path` must be repo-relative and forward-slash separated.
+    pub fn is_blocked(&self, path: &str) -> bool {
+        self.0.is_match(path)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patterns(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // -- Literal, *, **, ?, {a,b}, and [a-z] patterns -----------------------
+
+    #[test]
+    fn literal_pattern_matches_exact_path_only() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/Foo.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Bar.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Sub/Foo.uasset"));
+    }
+
+    #[test]
+    fn star_pattern_matches_within_one_directory_level() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Sub/Foo.uasset"));
+    }
+
+    #[test]
+    fn double_star_pattern_matches_at_any_depth() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/**/*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(result.matcher.is_blocked("Content/Sub/Foo.uasset"));
+        assert!(result.matcher.is_blocked("Content/Sub/Deeper/Foo.uasset"));
+    }
+
+    #[test]
+    fn question_mark_pattern_matches_single_character() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/Foo?.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Foo1.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Foo12.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Foo.uasset"));
+    }
+
+    #[test]
+    fn alternate_pattern_matches_either_branch() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/**/*.{uasset,umap}"]));
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(result.matcher.is_blocked("Content/Sub/Level.umap"));
+        assert!(!result.matcher.is_blocked("Content/Foo.txt"));
+    }
+
+    #[test]
+    fn character_class_pattern_matches_range() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/[A-C]*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Apple.uasset"));
+        assert!(result.matcher.is_blocked("Content/Banana.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Zebra.uasset"));
+    }
+
+    // -- literal_separator behavior (the semantics this module most depends
+    //    on getting right: without it, `*` and `?` would cross directory
+    //    boundaries, and a pattern like `Content/*.uasset` would incorrectly
+    //    match `Content/Sub/Foo.uasset`) --------------------------
+
+    #[test]
+    fn single_star_does_not_cross_directory_boundary() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/*.uasset"]));
+        assert!(
+            !result.matcher.is_blocked("Content/Sub/Foo.uasset"),
+            "Content/*.uasset must not match a nested path under literal_separator(true); \
+             globset's default (literal_separator(false)) would incorrectly match here"
+        );
+    }
+
+    #[test]
+    fn double_star_does_cross_directory_boundary() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/**/*.uasset"]));
+        assert!(
+            result.matcher.is_blocked("Content/Sub/Foo.uasset"),
+            "Content/**/*.uasset must match a nested path — ** is the escape hatch from \
+             literal_separator's directory-boundary restriction"
+        );
+    }
+
+    // -- Case-insensitivity, both directions --------------------------------
+
+    #[test]
+    fn matching_is_case_insensitive_pattern_upper_path_lower() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.UASSET"]));
+        assert!(result.matcher.is_blocked("Content/foo.uasset"));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive_pattern_lower_path_upper() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/FOO.UASSET"));
+    }
+
+    // -- Empty / absent pattern lists ---------------------------------------
+
+    #[test]
+    fn empty_pattern_list_matches_nothing() {
+        let result = BlockedFileMatcher::compile(&[]);
+        assert!(result.matcher.is_empty());
+        assert!(!result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(!result.matcher.is_blocked(""));
+        assert!(result.invalid.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn empty_matcher_matches_nothing() {
+        let matcher = BlockedFileMatcher::empty();
+        assert!(matcher.is_empty());
+        assert!(!matcher.is_blocked("Content/Foo.uasset"));
+    }
+
+    // -- Multiple / overlapping patterns -------------------------------------
+
+    #[test]
+    fn multiple_patterns_each_contribute_matches() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset", "**/*.umap"]));
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+        assert!(result.matcher.is_blocked("Content/Level.umap"));
+        assert!(!result.matcher.is_blocked("Content/Readme.txt"));
+    }
+
+    #[test]
+    fn overlapping_patterns_matching_the_same_path_are_not_an_error() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset", "Content/**"]));
+        assert!(result.invalid.is_empty());
+        // Both patterns independently match this path; is_blocked only
+        // reports true/false, not which pattern(s) fired.
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+    }
+
+    // -- Invalid patterns are skipped, valid siblings still match -----------
+
+    #[test]
+    fn invalid_pattern_is_skipped_and_reported_valid_sibling_still_matches() {
+        let result =
+            BlockedFileMatcher::compile(&patterns(&["Content/[unterminated", "**/*.uasset"]));
+        assert_eq!(result.invalid.len(), 1);
+        assert_eq!(result.invalid[0].0, "Content/[unterminated");
+        assert!(
+            !result.invalid[0].1.is_empty(),
+            "invalid entry must carry a non-empty error message"
+        );
+        assert!(result.matcher.is_blocked("Content/Foo.uasset"));
+    }
+
+    #[test]
+    fn all_invalid_patterns_yields_empty_matcher_not_an_error() {
+        // Both patterns are unambiguously malformed: an unterminated
+        // character class and an unterminated brace-alternate group.
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/[abc", "Content/{a,b"]));
+        assert_eq!(result.invalid.len(), 2);
+        assert!(result.matcher.is_empty());
+    }
+
+    // -- Under-match warning heuristic ---------------------------------------
+
+    #[test]
+    fn warning_fires_for_pattern_with_no_slash_and_no_double_star() {
+        let result = BlockedFileMatcher::compile(&patterns(&["*.uasset"]));
+        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(result.warnings[0].0, "*.uasset");
+        // The pattern is still compiled and used as-authored, not rewritten —
+        // the warning informs, it doesn't silently correct the user's intent.
+        assert!(result.matcher.is_blocked("Foo.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Foo.uasset"));
+    }
+
+    #[test]
+    fn warning_does_not_fire_for_double_star_pattern() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset"]));
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn warning_does_not_fire_for_pattern_containing_a_literal_slash() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/*.uasset"]));
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn warning_does_not_fire_for_an_invalid_pattern() {
+        // An invalid pattern is already reported via `invalid`; it should not
+        // also generate a redundant/confusing under-match warning.
+        let result = BlockedFileMatcher::compile(&patterns(&["[unterminated"]));
+        assert_eq!(result.invalid.len(), 1);
+        assert!(result.warnings.is_empty());
+    }
+
+    // -- Spaces and non-ASCII paths ------------------------------------------
+
+    #[test]
+    fn matches_path_with_spaces() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset"]));
+        assert!(result
+            .matcher
+            .is_blocked("Content/Environments/Foo Bar/Wall.uasset"));
+    }
+
+    #[test]
+    fn matches_path_with_non_ascii_characters() {
+        let result = BlockedFileMatcher::compile(&patterns(&["**/*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Café/Décor/Table.uasset"));
+        assert!(result
+            .matcher
+            .is_blocked("Content/キャラクター/Hero.uasset"));
+    }
+
+    #[test]
+    fn pattern_itself_may_contain_non_ascii_characters() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/Café/**"]));
+        assert!(result.matcher.is_blocked("Content/Café/Décor/Table.uasset"));
+        assert!(!result.matcher.is_blocked("Content/Other/Table.uasset"));
+    }
+
+    // -- Forward-slash assumption, pinned explicitly -------------------------
+
+    #[test]
+    fn matching_operates_on_forward_slash_separated_paths() {
+        // This module's documented contract (see the struct doc comment) is
+        // that `path` is repo-relative and forward-slash separated, matching
+        // exactly what `git status --porcelain` yields. This test pins that a
+        // pattern written with `/` reliably matches a `/`-separated candidate
+        // path on whichever platform the test suite runs on — this file has
+        // no #[cfg(windows)]/#[cfg(unix)] branches precisely because CI runs
+        // this same suite on both `build-linux` and `build-windows`
+        // (.github/workflows/rust.yml), and both must agree.
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/Sub/*.uasset"]));
+        assert!(result.matcher.is_blocked("Content/Sub/Foo.uasset"));
+    }
+
+    #[test]
+    fn a_path_using_backslash_separators_is_platform_dependent() {
+        // Callers must never hand this module a Windows-style backslash path
+        // (git never produces one; RepoStatus::File::path is always
+        // forward-slash) — but this pins the *actual*, verified behavior
+        // rather than assuming it is uniform across platforms.
+        //
+        // `GlobSet::is_match` takes `P: AsRef<Path>` and routes through
+        // `globset`'s internal `Candidate::new`, which normalizes the
+        // candidate via `pathutil::normalize_path`. That function is a
+        // documented no-op on Unix (verified in globset 0.4.19's
+        // `src/pathutil.rs`), so on Unix a literal `\` is just another
+        // character, not a separator, and does not multi-segment the path.
+        // On non-Unix platforms (Windows), the same function rewrites every
+        // byte for which `std::path::is_separator` holds — which includes
+        // `\` — to `/` before matching. So on Windows a backslash-separated
+        // candidate *is* normalized and does become multi-segment, purely
+        // as a side effect of globset's internal candidate preparation, not
+        // this module's own logic. That behavior is implementation-verified,
+        // not a documented API contract, so it is pinned here with a test
+        // that runs on both CI platforms (see .github/workflows/rust.yml's
+        // build-linux and build-windows jobs) rather than merely assumed.
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/Sub/*.uasset"]));
+        #[cfg(unix)]
+        assert!(!result.matcher.is_blocked("Content\\Sub\\Foo.uasset"));
+        #[cfg(not(unix))]
+        assert!(result.matcher.is_blocked("Content\\Sub\\Foo.uasset"));
+    }
+
+    // -- Deletion handling is explicitly NOT this module's job ---------------
+    //
+    // A deleted file must never be blocked — removing a wrongly-committed
+    // asset from a branch is the exact cleanup workflow this feature exists
+    // to preserve, and blocking it would leave manual git surgery as the only
+    // remedy. But that check depends on `FileState`, which this module has no
+    // notion of: `is_blocked` takes only a path. There is deliberately no
+    // `FileState` parameter here and therefore no test for it in this file —
+    // coverage for "deletions matching a blocked glob are not blocked" lives
+    // instead against the real `update_files_submit_status` call site in
+    // `friendshipper/src-tauri/src/repo/operations/status.rs`, since that is
+    // where the `FileState` check actually lives (see
+    // `deleted_blocked_path_is_not_blocked` there).
+
+    // -- Backslash patterns (Windows-style separators) -----------------------
+
+    #[test]
+    fn warning_fires_for_pattern_containing_backslash() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content\\Characters\\**"]));
+        assert!(
+            result.invalid.is_empty(),
+            "a backslash pattern still compiles: {:?}",
+            result.invalid
+        );
+        assert_eq!(
+            result.warnings.len(),
+            1,
+            "expected exactly one warning: {:?}",
+            result.warnings
+        );
+        assert_eq!(result.warnings[0].0, "Content\\Characters\\**");
+        assert!(result.warnings[0].1.contains('\\'));
+
+        // Whether the pattern *also* matches anything is platform-dependent
+        // (see a_path_using_backslash_separators_is_platform_dependent above
+        // for the same underlying reason) and is not the point of this
+        // warning: globset's parser normalizes `\` to `/` in the pattern
+        // whenever std::path::is_separator considers `\` a separator on the
+        // compiling platform, which is true on Windows and false on Unix.
+        // So on Windows this pattern is silently rewritten to
+        // `Content/Characters/**` and matches by accident; on Unix `\` stays
+        // literal and it matches nothing — the failure mode a Windows author
+        // testing locally would never observe.
+        #[cfg(unix)]
+        assert!(!result.matcher.is_blocked("Content/Characters/Hero.uasset"));
+        #[cfg(not(unix))]
+        assert!(result.matcher.is_blocked("Content/Characters/Hero.uasset"));
+    }
+
+    #[test]
+    fn warning_does_not_fire_for_pattern_without_backslash() {
+        let result = BlockedFileMatcher::compile(&patterns(&["Content/**/*.uasset"]));
+        assert!(result.warnings.is_empty());
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub use clients::aws::AWSClient;
 
 pub mod auth;
+pub mod blocked_files;
 pub mod clients;
 pub mod fs;
 pub mod longtail;

--- a/core/src/types/config.rs
+++ b/core/src/types/config.rs
@@ -282,6 +282,53 @@ impl AppConfig {
             None => repo_config.playtest_profiles = Some(vec![default_profile]),
         };
 
+        // Validate blocked-file globs for every target branch. This never fails
+        // the load — `friendshipper.yaml` is committed to the project repo, so
+        // a bad glob failing the load would brick app startup for every user of
+        // the project, not just the author who made the typo. This is the ONLY
+        // place these diagnostics are emitted; the on-demand compile at use
+        // sites (e.g. StatusOp) must stay silent, since status recomputes on
+        // every refresh and would otherwise spam the log continuously.
+        //
+        // The per-branch count is logged at INFO regardless of whether any
+        // patterns are configured: `#[serde(default)]` on `blocked_file_globs`
+        // means a misspelled key (e.g. `blockedFilesGlobs`) deserializes
+        // cleanly to an empty list rather than an error, so without this log
+        // an author who typos the key has no way to notice the field they set
+        // was never read.
+        for branch in &repo_config.target_branches {
+            let result =
+                crate::blocked_files::BlockedFileMatcher::compile(&branch.blocked_file_globs);
+
+            tracing::info!(
+                branch = %branch.name,
+                count = branch.blocked_file_globs.len(),
+                "loaded {} blockedFileGlobs pattern(s) for branch '{}'",
+                branch.blocked_file_globs.len(),
+                branch.name
+            );
+
+            for (pattern, message) in &result.invalid {
+                tracing::error!(
+                    branch = %branch.name,
+                    pattern = %pattern,
+                    "invalid blockedFileGlobs pattern for branch '{}': {}",
+                    branch.name,
+                    message
+                );
+            }
+
+            for (pattern, message) in &result.warnings {
+                tracing::warn!(
+                    branch = %branch.name,
+                    pattern = %pattern,
+                    "blockedFileGlobs pattern for branch '{}' may silently under-match: {}",
+                    branch.name,
+                    message
+                );
+            }
+        }
+
         Ok(repo_config)
     }
 
@@ -405,12 +452,25 @@ pub struct PlaytestProfile {
     args: String,
 }
 
+/// Serde default for `TargetBranchConfig::uses_merge_queue`. A plain
+/// `#[serde(default)]` would fall back to `bool::default()` (`false`), which
+/// contradicts `TargetBranchConfig::default()` below (`true`) — a config
+/// entry that omits `usesMergeQueue` would silently disable the merge-queue
+/// submit path and hide the merge-queue UI instead of matching the struct's
+/// own default.
+fn default_uses_merge_queue() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TargetBranchConfig {
     pub name: String,
 
-    #[serde(rename = "usesMergeQueue")]
+    #[serde(default = "default_uses_merge_queue", rename = "usesMergeQueue")]
     pub uses_merge_queue: bool,
+
+    #[serde(default, rename = "blockedFileGlobs")]
+    pub blocked_file_globs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -434,6 +494,7 @@ impl Default for TargetBranchConfig {
         TargetBranchConfig {
             name: "main".to_string(),
             uses_merge_queue: true,
+            blocked_file_globs: Vec::new(),
         }
     }
 }
@@ -539,6 +600,23 @@ impl RepoConfig {
             .map(|url| url.trim_end_matches('/').to_string());
         Ok(config)
     }
+
+    /// Blocked globs for the named branch. Returns an empty slice when the
+    /// branch is not present in `target_branches` — callers must treat that
+    /// as "nothing blocked" rather than an error. `StatusOp` runs constantly
+    /// to keep the UI live, so a `target_branch` that doesn't (yet, or no
+    /// longer) match an entry in `target_branches` must degrade gracefully
+    /// instead of hard-failing status computation for the whole app; this
+    /// method returning an empty slice for an unknown branch IS that
+    /// degrade-to-nothing-blocked behavior, so no separate guard is needed at
+    /// call sites.
+    pub fn blocked_globs_for_branch(&self, branch: &str) -> &[String] {
+        self.target_branches
+            .iter()
+            .find(|b| b.name == branch)
+            .map(|b| b.blocked_file_globs.as_slice())
+            .unwrap_or(&[])
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -641,6 +719,184 @@ pub struct UnrealVerSelDiagResponse {
 #[cfg(test)]
 mod tests {
     use crate::types::config::CUSTOM_ENGINE_ASSOCIATION_REGEX;
+    use crate::types::config::{AppConfig, ProjectRepoConfig, RepoConfig, TargetBranchConfig};
+    use tempfile::TempDir;
+
+    /// Writes `yaml` to `<tempdir>/friendshipper.yaml` and runs it through the
+    /// real `AppConfig::initialize_repo_config` path. Returns the tempdir guard
+    /// alongside the result so the directory isn't dropped (and deleted) before
+    /// the caller is done with it.
+    fn load_repo_config_from_yaml(yaml: &str) -> (TempDir, Result<RepoConfig, anyhow::Error>) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        std::fs::write(dir.path().join("friendshipper.yaml"), yaml)
+            .expect("write friendshipper.yaml");
+
+        let mut app_config = AppConfig::new("test");
+        app_config.selected_artifact_project = Some("test-project".to_string());
+        app_config.projects.insert(
+            "test-project".to_string(),
+            ProjectRepoConfig {
+                repo_path: dir.path().to_string_lossy().to_string(),
+                repo_url: String::new(),
+            },
+        );
+
+        let result = app_config.initialize_repo_config();
+        (dir, result)
+    }
+
+    #[test]
+    fn test_repo_config_without_blocked_file_globs_still_loads() {
+        let yaml = r#"
+uprojectPath: "Game.uproject"
+targetBranches:
+  - name: main
+    usesMergeQueue: true
+"#;
+
+        let (_dir, result) = load_repo_config_from_yaml(yaml);
+        let repo_config = result.expect("config with no blockedFileGlobs must still deserialize");
+
+        assert_eq!(repo_config.target_branches.len(), 1);
+        assert!(repo_config.target_branches[0].blocked_file_globs.is_empty());
+    }
+
+    #[test]
+    fn test_target_branch_without_uses_merge_queue_defaults_to_true() {
+        // The serde default for `uses_merge_queue` must match
+        // `TargetBranchConfig::default()` (`true`). Before this test's fix,
+        // `#[serde(default)]` fell back to `bool::default()` (`false`)
+        // instead, so a `targetBranches` entry that simply omits
+        // `usesMergeQueue` — which every project's config validly could —
+        // would silently flip the merge-queue submit path and hide the
+        // merge-queue UI, in a way that previously failed loudly (a missing
+        // field failed the deserialize entirely) but now would not.
+        let yaml = r#"
+targetBranches:
+  - name: content-main
+"#;
+
+        let (_dir, result) = load_repo_config_from_yaml(yaml);
+        let repo_config =
+            result.expect("targetBranches entry omitting usesMergeQueue must deserialize");
+
+        assert_eq!(repo_config.target_branches.len(), 1);
+        assert_eq!(repo_config.target_branches[0].name, "content-main");
+        assert!(
+            repo_config.target_branches[0].uses_merge_queue,
+            "uses_merge_queue must default to true, matching TargetBranchConfig::default()"
+        );
+    }
+
+    #[test]
+    fn test_camel_case_blocked_file_globs_populates_field() {
+        let yaml = r#"
+targetBranches:
+  - name: main
+    usesMergeQueue: true
+    blockedFileGlobs:
+      - "**/*.uasset"
+      - "**/*.umap"
+  - name: content-main
+    usesMergeQueue: false
+"#;
+
+        let (_dir, result) = load_repo_config_from_yaml(yaml);
+        let repo_config = result.expect("config with blockedFileGlobs must deserialize");
+
+        assert_eq!(repo_config.target_branches.len(), 2);
+
+        let main_branch = repo_config
+            .target_branches
+            .iter()
+            .find(|b| b.name == "main")
+            .expect("main branch present");
+        assert_eq!(
+            main_branch.blocked_file_globs,
+            vec!["**/*.uasset".to_string(), "**/*.umap".to_string()]
+        );
+
+        let content_branch = repo_config
+            .target_branches
+            .iter()
+            .find(|b| b.name == "content-main")
+            .expect("content-main branch present");
+        assert!(content_branch.blocked_file_globs.is_empty());
+    }
+
+    #[test]
+    fn test_target_branch_config_serializes_camel_case() {
+        let branch = TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: true,
+            blocked_file_globs: vec!["**/*.uasset".to_string()],
+        };
+
+        let json = serde_json::to_string(&branch).expect("serialize");
+        assert!(json.contains("\"usesMergeQueue\":true"));
+        assert!(json.contains("\"blockedFileGlobs\":[\"**/*.uasset\"]"));
+        assert!(!json.contains("uses_merge_queue"));
+        assert!(!json.contains("blocked_file_globs"));
+    }
+
+    #[test]
+    fn test_blocked_globs_for_branch_unknown_branch_returns_empty() {
+        let repo_config = RepoConfig {
+            target_branches: vec![TargetBranchConfig {
+                name: "main".to_string(),
+                uses_merge_queue: true,
+                blocked_file_globs: vec!["**/*.uasset".to_string()],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            repo_config.blocked_globs_for_branch("main"),
+            &["**/*.uasset".to_string()]
+        );
+        assert!(repo_config
+            .blocked_globs_for_branch("some-branch-not-in-config")
+            .is_empty());
+    }
+
+    #[test]
+    fn test_malformed_glob_does_not_fail_config_load() {
+        // Use the same invalid-pattern example as core/src/blocked_files.rs's
+        // own test suite for consistency. An unterminated character class is
+        // a reliable example of a pattern globset's GlobBuilder rejects.
+        let yaml = r#"
+targetBranches:
+  - name: main
+    usesMergeQueue: true
+    blockedFileGlobs:
+      - "Content/[unterminated"
+"#;
+
+        let (_dir, result) = load_repo_config_from_yaml(yaml);
+
+        // Half 1: load must succeed despite the malformed pattern — a bad
+        // glob must never brick app startup, since friendshipper.yaml is
+        // committed to the project repo and a typo would otherwise take down
+        // the tool for every user of the project, not just its author.
+        let repo_config = result.expect("a malformed glob must not fail config load");
+        assert_eq!(
+            repo_config.target_branches[0].blocked_file_globs,
+            vec!["Content/[unterminated".to_string()],
+            "the raw pattern list is preserved as-is; validation only logs, it does not filter"
+        );
+
+        // Half 2: the same pattern, run through the same validation primitive
+        // initialize_repo_config uses internally, is in fact flagged invalid —
+        // this is what would have been logged at ERROR during the load above.
+        let validation = crate::blocked_files::BlockedFileMatcher::compile(
+            &repo_config.target_branches[0].blocked_file_globs,
+        );
+        assert_eq!(
+            validation.invalid.len(),
+            1,
+            "expected the malformed pattern to be caught by BlockedFileMatcher::compile"
+        );
+    }
 
     #[test]
     fn test_engine_association_regex() {

--- a/core/src/types/repo.rs
+++ b/core/src/types/repo.rs
@@ -10,6 +10,9 @@ pub enum SubmitStatus {
     CheckedOutByOtherUser,
     Unmerged,
     Conflicted,
+    Blocked,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -505,6 +508,92 @@ mod tests {
         assert_eq!(status.remote_branch, "");
         assert_eq!(status.commits_ahead, 0);
         assert_eq!(status.commits_behind, 0);
+    }
+
+    #[test]
+    fn test_submit_status_round_trips_known_variants() {
+        let cases = [
+            (SubmitStatus::Ok, "\"Ok\""),
+            (SubmitStatus::CheckoutRequired, "\"CheckoutRequired\""),
+            (
+                SubmitStatus::CheckedOutByOtherUser,
+                "\"CheckedOutByOtherUser\"",
+            ),
+            (SubmitStatus::Unmerged, "\"Unmerged\""),
+            (SubmitStatus::Conflicted, "\"Conflicted\""),
+            (SubmitStatus::Blocked, "\"Blocked\""),
+            (SubmitStatus::Unknown, "\"Unknown\""),
+        ];
+
+        for (variant, expected_json) in cases {
+            let serialized = serde_json::to_string(&variant).expect("serialize");
+            assert_eq!(
+                serialized, expected_json,
+                "serialization changed for {variant:?}"
+            );
+
+            let deserialized: SubmitStatus =
+                serde_json::from_str(&serialized).expect("deserialize");
+            assert_eq!(
+                deserialized, variant,
+                "round trip did not return the same variant for {variant:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_submit_status_unrecognized_string_becomes_unknown() {
+        let result: SubmitStatus = serde_json::from_str("\"SomeFutureVariantThatDoesNotExistYet\"")
+            .expect("an unrecognized submitStatus string must deserialize successfully, not error");
+        assert_eq!(result, SubmitStatus::Unknown);
+    }
+
+    #[test]
+    fn test_submit_status_malformed_json_still_errors() {
+        // Sanity check: tolerance is for unrecognized *variant names*, not for
+        // malformed JSON in general. A non-string value must still fail.
+        let result = serde_json::from_str::<SubmitStatus>("42");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_changeset_payload_with_unknown_submit_status_loads() {
+        let json = r#"[
+            {
+                "name": "default",
+                "files": [
+                    {
+                        "path": "Content/Foo.uasset",
+                        "displayName": "Foo.uasset",
+                        "state": "Modified",
+                        "isStaged": false,
+                        "lockedBy": "",
+                        "submitStatus": "SomeFutureVariantFromANewerBuild"
+                    },
+                    {
+                        "path": "Source/Bar.cpp",
+                        "displayName": "Bar.cpp",
+                        "state": "Modified",
+                        "isStaged": false,
+                        "lockedBy": "",
+                        "submitStatus": "Ok"
+                    }
+                ],
+                "open": true,
+                "checked": false,
+                "indeterminate": false
+            }
+        ]"#;
+
+        // This is the exact call made by `load_changeset` in
+        // friendshipper/src-tauri/src/repo/operations/changeset.rs:162-168.
+        let changesets: Vec<ChangeSet> = serde_json::from_str(json)
+            .expect("changesets.json with an unknown variant must still load");
+
+        assert_eq!(changesets.len(), 1);
+        assert_eq!(changesets[0].files.len(), 2);
+        assert_eq!(changesets[0].files[0].submit_status, SubmitStatus::Unknown);
+        assert_eq!(changesets[0].files[1].submit_status, SubmitStatus::Ok);
     }
 
     #[test]

--- a/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
+++ b/core/ui/src/lib/components/repo/ModifiedFilesCard.svelte
@@ -361,6 +361,25 @@
 			tooltip = ': Unable to submit - unmerged file requires a revert';
 		} else if (file.submitStatus === SubmitStatus.Conflicted) {
 			tooltip = ': Unable to submit - conflicted file requires a revert';
+		} else if (file.submitStatus === SubmitStatus.Blocked) {
+			tooltip =
+				': Unable to submit - this file type is blocked from being submitted to the current target branch';
+			// `Blocked` takes precedence over every other submit status on the
+			// backend (see update_files_submit_status in status.rs), so a file
+			// that is simultaneously unmerged loses that information once
+			// submitStatus collapses to a single value - the user would see
+			// only "this file type is blocked" with no hint that reverting
+			// would also fix an unmerged state out from under it. `file.state`
+			// is a separate field that survives that collapse, so the
+			// unmerged case is still detectable here and worth surfacing
+			// additively. The analogous "this file is also upstream-
+			// conflicted" case is not: RepoStatus.conflicts (the list an
+			// upstream conflict is derived from) is never sent to this
+			// component - only individual ModifiedFile entries are - so there
+			// is no client-side signal to detect it from.
+			if (file.state === ModifiedFileState.Unmerged) {
+				tooltip += '; this file is also unmerged - reverting it will resolve both issues';
+			}
 		}
 
 		return file.state + tooltip;

--- a/core/ui/src/lib/types/repo.ts
+++ b/core/ui/src/lib/types/repo.ts
@@ -11,7 +11,9 @@ export enum SubmitStatus {
 	CheckoutRequired = 'CheckoutRequired',
 	CheckedOutByOtherUser = 'CheckedOutByOtherUser',
 	Unmerged = 'Unmerged',
-	Conflicted = 'Conflicted'
+	Conflicted = 'Conflicted',
+	Blocked = 'Blocked',
+	Unknown = 'Unknown'
 }
 
 export enum SortKey {

--- a/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
+++ b/friendshipper/src-tauri/src/repo/operations/gh/submit.rs
@@ -28,7 +28,7 @@ use ethos_core::types::errors::CoreError;
 use ethos_core::types::github::TokenNotFoundError;
 use ethos_core::types::locks::LockOperation;
 use ethos_core::types::repo::SubmitStatus;
-use ethos_core::types::repo::{File, PushRequest};
+use ethos_core::types::repo::{File, PushRequest, RepoStatus};
 use ethos_core::worker::{Task, TaskSequence};
 use ethos_core::AWSClient;
 
@@ -326,6 +326,120 @@ async fn find_files_with_conflict_markers(
     }
     let diff = String::from_utf8_lossy(&diff_out.stdout);
     Ok(confirm_paired_markers(&diff, &candidates, marker_size))
+}
+
+/// Checks the current repo status for files that cannot be submitted —
+/// checkout-required, checked-out-by-another-user, unmerged, conflicted, or
+/// blocked by `blockedFileGlobs` — and returns a descriptive error naming
+/// them grouped by reason. Returns `Ok(())` if every requested file is
+/// submittable.
+///
+/// Deliberately takes no `GraphQLClient`: this function is called before any
+/// GitHub interaction, and keeping it free of that dependency lets it be
+/// exercised in tests without a live, authenticated GitHub client (which
+/// `GraphQLClient::new` requires — see `core/src/clients/github.rs`).
+async fn reject_unsubmittable_files<T: EngineProvider>(
+    requested_files: &[String],
+    repo_status: &RepoStatus,
+    app_config: &AppConfigRef,
+    repo_config: &RepoConfigRef,
+    engine: &T,
+) -> Result<(), CoreError> {
+    let mut unsubmittable_files: Vec<File> = vec![];
+
+    for file in requested_files.iter() {
+        let mut all_modified_iter = repo_status
+            .modified_files
+            .0
+            .iter()
+            .chain(repo_status.untracked_files.0.iter());
+        if let Some(file) = all_modified_iter.find(|x| x.path == *file) {
+            match file.submit_status {
+                // `Unknown` only ever arises from deserializing a submit
+                // status this build doesn't recognize (e.g. changesets.json
+                // written by a newer build, then loaded after a rollback);
+                // `StatusOp` runs immediately before this gate and recomputes
+                // every status from scratch, so a value it actually produced
+                // is never `Unknown` in practice. Treat it like `Ok` here so
+                // the backend agrees with the frontend gating in
+                // `+page.svelte`'s `hasUnsubmittableFiles` — failing closed
+                // on it would reject a submit for no defensible reason.
+                SubmitStatus::Ok | SubmitStatus::Unknown => {}
+                _ => unsubmittable_files.push(file.clone()),
+            }
+        }
+    }
+
+    if unsubmittable_files.is_empty() {
+        return Ok(());
+    }
+
+    let engine_path = app_config
+        .read()
+        .load_engine_path_from_repo(&repo_config.read())
+        .unwrap_or_default();
+    let unsubmittable_file_paths: Vec<String> =
+        unsubmittable_files.iter().map(|x| x.path.clone()).collect();
+
+    let unsubmittable_display_names = engine
+        .get_asset_display_names(
+            CommunicationType::None,
+            &engine_path,
+            &unsubmittable_file_paths,
+        )
+        .await;
+
+    // Group by reason so the toast reads as "here are your N blocked files"
+    // rather than N separate lines repeating the same explanation.
+    let mut by_reason: Vec<(&'static str, Vec<String>)> = vec![];
+
+    for (file, display_name) in unsubmittable_files
+        .iter()
+        .zip(unsubmittable_display_names.iter())
+    {
+        let name_formatted: String = if display_name.is_empty() {
+            file.path.clone()
+        } else {
+            format!("{} ({})", display_name, file.path)
+        };
+        let reason = match file.submit_status {
+            // Both variants are filtered out of `unsubmittable_files` above,
+            // so neither can reach this match — combined into one arm rather
+            // than giving `Unknown` its own (dead) reason string, which would
+            // misleadingly imply it is still rejected here.
+            SubmitStatus::Ok | SubmitStatus::Unknown => {
+                panic!("should have been filtered out by above code")
+            }
+            SubmitStatus::CheckoutRequired => "This file is an asset and must be checked out (locked) before submitting",
+            SubmitStatus::CheckedOutByOtherUser => "This file is an asset and must be checked out (locked) before submitting, but it is locked by another user",
+            SubmitStatus::Unmerged => "This file is unmerged and must be reverted to continue",
+            SubmitStatus::Conflicted => "A newer version of this file exists; this file must be reverted to continue",
+            SubmitStatus::Blocked => "This file matches a blocked-file-glob pattern configured for this target branch and cannot be submitted",
+        };
+        tracing::error!("{}: {}", reason, name_formatted);
+
+        match by_reason.iter_mut().find(|(r, _)| *r == reason) {
+            Some((_, paths)) => paths.push(name_formatted),
+            None => by_reason.push((reason, vec![name_formatted])),
+        }
+    }
+
+    const MAX_PATHS_PER_REASON: usize = 10;
+    let mut message = String::from("Some files are not allowed to be submitted:\n");
+    for (reason, paths) in &by_reason {
+        message.push_str(&format!("\n{reason}:\n"));
+        for path in paths.iter().take(MAX_PATHS_PER_REASON) {
+            message.push_str(&format!("  - {path}\n"));
+        }
+        if paths.len() > MAX_PATHS_PER_REASON {
+            message.push_str(&format!(
+                "  ...and {} more\n",
+                paths.len() - MAX_PATHS_PER_REASON
+            ));
+        }
+    }
+
+    Err(CoreError::Input(anyhow!(message)))
 }
 
 /// Count the leading run of byte `c` at the start of `s`. Used to recognize a
@@ -695,60 +809,14 @@ where
         // abort if we are trying to submit any conflicted files, or files that should be locked, but aren't
         {
             let repo_status = self.repo_status.read().clone();
-            let mut unsubmittable_files: Vec<File> = vec![];
-
-            for file in self.files.iter() {
-                let mut all_modified_iter = repo_status
-                    .modified_files
-                    .0
-                    .iter()
-                    .chain(repo_status.untracked_files.0.iter());
-                if let Some(file) = all_modified_iter.find(|x| x.path == *file) {
-                    match file.submit_status {
-                        SubmitStatus::Ok => {}
-                        _ => unsubmittable_files.push(file.clone()),
-                    }
-                }
-            }
-
-            if !unsubmittable_files.is_empty() {
-                let engine_path = self
-                    .app_config
-                    .read()
-                    .load_engine_path_from_repo(&self.repo_config.read())
-                    .unwrap_or_default();
-                let unsubmittable_file_paths: Vec<String> =
-                    unsubmittable_files.iter().map(|x| x.path.clone()).collect();
-
-                let unsubmittable_display_names = self
-                    .engine
-                    .get_asset_display_names(
-                        CommunicationType::None,
-                        &engine_path,
-                        &unsubmittable_file_paths,
-                    )
-                    .await;
-
-                for (file, display_name) in unsubmittable_files
-                    .iter()
-                    .zip(unsubmittable_display_names.iter())
-                {
-                    let name_formatted: String = if display_name.is_empty() {
-                        file.path.clone()
-                    } else {
-                        format!("{} ({})", display_name, file.path)
-                    };
-                    let reason = match file.submit_status {
-                        SubmitStatus::Ok => panic!("should have been filtered out by above code"),
-                        SubmitStatus::CheckoutRequired => "This file is an asset and must be checked out (locked) before submitting",
-                        SubmitStatus::CheckedOutByOtherUser => "This file is an asset and must be checked out (locked) before submitting, but it is locked by another user",
-                        SubmitStatus::Unmerged => "This file is unmerged and must be reverted to continue",
-                        SubmitStatus::Conflicted => "A newer version of this file exists; this file must be reverted to continue",
-                    };
-                    tracing::error!("{}: {}", reason, name_formatted);
-                }
-                return Err(CoreError::Input(anyhow!("Some files are not allowed to be submitted. Check the log for specific errors.")));
-            }
+            reject_unsubmittable_files(
+                &self.files,
+                &repo_status,
+                &self.app_config,
+                &self.repo_config,
+                &self.engine,
+            )
+            .await?;
         }
 
         // Refuse to ship files with unresolved git conflict markers. We
@@ -1437,6 +1505,11 @@ mod tests {
     use super::*;
     use std::fs;
     use std::sync::mpsc;
+    use std::sync::Arc;
+
+    use ethos_core::types::config::{AppConfig, RepoConfig};
+    use ethos_core::types::repo::FileList;
+    use parking_lot::RwLock;
 
     /// Initialize an empty git repo with one initial commit so HEAD resolves.
     /// Returns the temp dir guard (drop = cleanup) and a `Git` client pointed
@@ -1471,6 +1544,239 @@ mod tests {
             .expect("initial commit");
 
         (dir, git)
+    }
+
+    /// A real `UnrealEngineProvider`, built without any I/O
+    /// (`new_from_config` is a pure field-mapping constructor — see
+    /// `engine/unreal/provider.rs`). Used to exercise the exact
+    /// `get_asset_display_names` call `reject_unsubmittable_files` makes,
+    /// rather than a mock.
+    fn test_engine() -> crate::engine::UnrealEngineProvider {
+        crate::engine::UnrealEngineProvider::new_from_config(
+            AppConfig::new(crate::APP_NAME),
+            RepoConfig::default(),
+        )
+    }
+
+    fn test_app_and_repo_config() -> (AppConfigRef, RepoConfigRef) {
+        (
+            Arc::new(RwLock::new(AppConfig::new(crate::APP_NAME))),
+            Arc::new(RwLock::new(RepoConfig::default())),
+        )
+    }
+
+    #[tokio::test]
+    async fn rejects_with_message_naming_the_blocked_file() {
+        // Two files, two different reasons — proves the message both names
+        // the blocked file and groups by reason rather than interleaving.
+        let repo_status = RepoStatus {
+            modified_files: FileList(vec![
+                File {
+                    path: "Content/Blocked.uasset".to_string(),
+                    submit_status: SubmitStatus::Blocked,
+                    ..Default::default()
+                },
+                File {
+                    path: "Content/NeedsCheckout.uasset".to_string(),
+                    submit_status: SubmitStatus::CheckoutRequired,
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        let requested_files = vec![
+            "Content/Blocked.uasset".to_string(),
+            "Content/NeedsCheckout.uasset".to_string(),
+        ];
+        let (app_config, repo_config) = test_app_and_repo_config();
+        let engine = test_engine();
+
+        let result = reject_unsubmittable_files(
+            &requested_files,
+            &repo_status,
+            &app_config,
+            &repo_config,
+            &engine,
+        )
+        .await;
+
+        let err = match result {
+            Err(CoreError::Input(e)) => e,
+            other => panic!("expected CoreError::Input, got {other:?}"),
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("Content/Blocked.uasset"),
+            "message missing blocked path: {message}"
+        );
+        assert!(
+            message.contains("Content/NeedsCheckout.uasset"),
+            "message missing checkout-required path: {message}"
+        );
+        assert!(
+            message.contains("blocked-file-glob"),
+            "message missing the blocked-specific reason text: {message}"
+        );
+        assert!(
+            message.contains("checked out (locked)"),
+            "message missing the checkout-required reason text: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn truncates_long_file_lists() {
+        let mut files = Vec::new();
+        let mut requested = Vec::new();
+        for i in 0..15 {
+            let path = format!("Content/Blocked{i}.uasset");
+            files.push(File {
+                path: path.clone(),
+                submit_status: SubmitStatus::Blocked,
+                ..Default::default()
+            });
+            requested.push(path);
+        }
+        let repo_status = RepoStatus {
+            modified_files: FileList(files),
+            ..Default::default()
+        };
+        let (app_config, repo_config) = test_app_and_repo_config();
+        let engine = test_engine();
+
+        let err = reject_unsubmittable_files(
+            &requested,
+            &repo_status,
+            &app_config,
+            &repo_config,
+            &engine,
+        )
+        .await
+        .expect_err("must reject");
+        let message = err.to_string();
+
+        for i in 0..10 {
+            assert!(
+                message.contains(&format!("Content/Blocked{i}.uasset")),
+                "message missing path {i}: {message}"
+            );
+        }
+        for i in 10..15 {
+            assert!(
+                !message.contains(&format!("Content/Blocked{i}.uasset")),
+                "message should have truncated path {i}: {message}"
+            );
+        }
+        assert!(
+            message.contains("...and 5 more"),
+            "message missing truncation suffix: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_status_is_treated_as_submittable() {
+        // `Unknown` is a deserialization fallback for a submit status this
+        // build doesn't recognize (e.g. changesets.json written by a newer
+        // build, then loaded after a rollback). `StatusOp` runs immediately
+        // before this gate and recomputes every status from scratch, so a
+        // value it actually produces is never `Unknown` in practice — but if
+        // it somehow does reach here, it must be treated exactly like `Ok`
+        // (matching the frontend's `hasUnsubmittableFiles` gating), not
+        // rejected. This also guards against a `panic!` regression: if
+        // `Unknown` were ever removed from the collection loop's `Ok |
+        // Unknown` arm above without also removing it from the exhaustive
+        // reason match, it would hit the `panic!("should have been filtered
+        // out...")` arm instead of returning a clean value.
+        let repo_status = RepoStatus {
+            modified_files: FileList(vec![File {
+                path: "Content/Mystery.uasset".to_string(),
+                submit_status: SubmitStatus::Unknown,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let requested_files = vec!["Content/Mystery.uasset".to_string()];
+        let (app_config, repo_config) = test_app_and_repo_config();
+        let engine = test_engine();
+
+        let result = reject_unsubmittable_files(
+            &requested_files,
+            &repo_status,
+            &app_config,
+            &repo_config,
+            &engine,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "an Unknown submit status must be treated as submittable, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_git_state_mutated_on_rejection() {
+        let (dir, git) = make_test_repo().await;
+        let path = "Content/Blocked.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v1\n").unwrap();
+
+        async fn snapshot(git: &git::Git) -> (String, Vec<String>, String, String) {
+            let head = git
+                .run_and_collect_output(&["rev-parse", "HEAD"], git::Opts::default())
+                .await
+                .expect("rev-parse HEAD");
+            let mut branches: Vec<String> = git
+                .run_and_collect_output(
+                    &["for-each-ref", "--format=%(refname)", "refs/heads"],
+                    git::Opts::default(),
+                )
+                .await
+                .expect("for-each-ref")
+                .lines()
+                .map(|s| s.to_string())
+                .collect();
+            branches.sort();
+            let stash = git
+                .run_and_collect_output(&["stash", "list"], git::Opts::default())
+                .await
+                .expect("stash list");
+            let status = git.status(vec![]).await.expect("status");
+            (head, branches, stash, status)
+        }
+
+        let before = snapshot(&git).await;
+
+        let repo_status = RepoStatus {
+            untracked_files: FileList(vec![File {
+                path: path.to_string(),
+                submit_status: SubmitStatus::Blocked,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let requested_files = vec![path.to_string()];
+        let (app_config, repo_config) = test_app_and_repo_config();
+        let engine = test_engine();
+
+        let result = reject_unsubmittable_files(
+            &requested_files,
+            &repo_status,
+            &app_config,
+            &repo_config,
+            &engine,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(CoreError::Input(_))),
+            "expected the blocked file to be rejected, got {result:?}"
+        );
+
+        let after = snapshot(&git).await;
+        assert_eq!(
+            before, after,
+            "reject_unsubmittable_files must not mutate any git state — no stash, \
+             no new branch, no index/HEAD change"
+        );
     }
 
     #[tokio::test]

--- a/friendshipper/src-tauri/src/repo/operations/status.rs
+++ b/friendshipper/src-tauri/src/repo/operations/status.rs
@@ -16,6 +16,7 @@ use crate::engine;
 use crate::engine::EngineProvider;
 use crate::repo::operations::gh::submit::is_quicksubmit_branch;
 use crate::state::AppState;
+use ethos_core::blocked_files::BlockedFileMatcher;
 use ethos_core::clients::aws::ensure_aws_client;
 use ethos_core::clients::git;
 use ethos_core::storage::ArtifactStorage;
@@ -349,9 +350,39 @@ where
         }
 
         {
+            // Compiled once, outside the closure below, since that closure is
+            // invoked twice (once for untracked files, once for modified
+            // files). Warnings and invalid-pattern diagnostics are handled
+            // once at config load (`initialize_repo_config`) and are
+            // deliberately discarded here — this closure runs on every
+            // status refresh (constantly, to keep the UI live) and must stay
+            // silent, or logging would spam continuously.
+            let blocked_matcher = {
+                let globs = self
+                    .repo_config
+                    .read()
+                    .blocked_globs_for_branch(&target_branch)
+                    .to_vec();
+                BlockedFileMatcher::compile(&globs).matcher
+            };
+
             let update_files_submit_status = |files: &mut [File]| {
                 for file in files.iter_mut() {
-                    if file.state == FileState::Unmerged {
+                    // `!blocked_matcher.is_empty()` is checked first because
+                    // `GlobSet::is_match` (behind `is_blocked`) builds a
+                    // `Candidate` — path normalization plus an allocation —
+                    // before its own internal empty-set short-circuit. Most
+                    // target branches configure no blocked globs at all, and
+                    // this closure runs on every file on every status
+                    // refresh, so skipping straight past that allocation
+                    // when there is nothing to match against is worth doing
+                    // explicitly rather than relying on GlobSet to notice.
+                    if !blocked_matcher.is_empty()
+                        && file.state != FileState::Deleted
+                        && blocked_matcher.is_blocked(&file.path)
+                    {
+                        file.submit_status = SubmitStatus::Blocked;
+                    } else if file.state == FileState::Unmerged {
                         file.submit_status = SubmitStatus::Unmerged;
                     } else if status.conflicts.iter().any(|x| x == &file.path) {
                         file.submit_status = SubmitStatus::Conflicted;
@@ -707,9 +738,443 @@ where
 #[cfg(test)]
 mod tests {
 
+    use std::fs;
+    use std::sync::mpsc;
+
     use ethos_core::storage::ArtifactEntry;
+    use ethos_core::types::config::{AppConfig, RepoConfig, TargetBranchConfig};
 
     use super::*;
+
+    /// Initialize a local git repo with a real (also-local) `origin` remote,
+    /// carrying both `main` and `content-main` branches — the two branches
+    /// `blocked_globs_for_branch` tests below key off. `StatusOp::run()`
+    /// unconditionally diffs against `origin/<name>` for every configured
+    /// `target_branches` entry (see `get_modified_upstream`), so every
+    /// branch name a test's `RepoConfig` mentions must exist on this remote
+    /// or `run()` fails outright — this fixture exists to make that always
+    /// true regardless of which of the two branches an individual test uses.
+    async fn make_test_repo_with_remote() -> (tempfile::TempDir, tempfile::TempDir, git::Git) {
+        let local_dir = tempfile::tempdir().expect("create local tempdir");
+        let remote_dir = tempfile::tempdir().expect("create remote tempdir");
+        let (tx, _rx) = mpsc::channel::<String>();
+        let local_git = git::Git::new(local_dir.path().to_path_buf(), tx.clone());
+        let remote_git = git::Git::new(remote_dir.path().to_path_buf(), tx);
+
+        remote_git
+            .run(&["init", "-q"], git::Opts::default())
+            .await
+            .expect("git init remote");
+        remote_git
+            .run(
+                &["config", "user.email", "test@example.com"],
+                git::Opts::default(),
+            )
+            .await
+            .expect("set remote user.email");
+        remote_git
+            .run(&["config", "user.name", "Test"], git::Opts::default())
+            .await
+            .expect("set remote user.name");
+        // Keep the remote's checked-out HEAD off of `main`/`content-main` so
+        // pushing either from local doesn't trip git's "refusing to update
+        // checked out branch" guard.
+        remote_git
+            .run(&["checkout", "-q", "-b", "temp"], git::Opts::default())
+            .await
+            .expect("create remote temp branch");
+
+        local_git
+            .run(&["init", "-q"], git::Opts::default())
+            .await
+            .expect("git init local");
+        local_git
+            .run(
+                &["config", "user.email", "test@example.com"],
+                git::Opts::default(),
+            )
+            .await
+            .expect("set local user.email");
+        local_git
+            .run(&["config", "user.name", "Test"], git::Opts::default())
+            .await
+            .expect("set local user.name");
+        local_git
+            .run(
+                &[
+                    "remote",
+                    "add",
+                    "origin",
+                    remote_dir.path().to_str().expect("utf8 remote path"),
+                ],
+                git::Opts::default(),
+            )
+            .await
+            .expect("add origin remote");
+        local_git
+            .run(&["checkout", "-q", "-b", "main"], git::Opts::default())
+            .await
+            .expect("checkout main");
+
+        fs::write(local_dir.path().join("seed.txt"), "seed\n").expect("write seed");
+        local_git
+            .run(&["add", "seed.txt"], git::Opts::default())
+            .await
+            .expect("git add seed");
+        local_git
+            .run(&["commit", "-qm", "seed"], git::Opts::default())
+            .await
+            .expect("initial commit");
+        local_git
+            .run(
+                &["push", "-q", "-u", "origin", "main"],
+                git::Opts::default(),
+            )
+            .await
+            .expect("push main");
+
+        local_git
+            .run(
+                &["checkout", "-q", "-b", "content-main"],
+                git::Opts::default(),
+            )
+            .await
+            .expect("checkout content-main");
+        local_git
+            .run(
+                &["push", "-q", "-u", "origin", "content-main"],
+                git::Opts::default(),
+            )
+            .await
+            .expect("push content-main");
+        local_git
+            .run(&["checkout", "-q", "main"], git::Opts::default())
+            .await
+            .expect("back to main");
+
+        (local_dir, remote_dir, local_git)
+    }
+
+    /// Build a `StatusOp<UnrealEngineProvider>` against a real repo fixture.
+    /// `skip_display_names`/`skip_engine_update` are both `true` so no
+    /// network or IPC calls are attempted — this is a fully hermetic,
+    /// offline exercise of the exact code path production uses.
+    fn build_status_op(
+        git_client: git::Git,
+        repo_path: &std::path::Path,
+        target_branch: &str,
+        target_branches: Vec<TargetBranchConfig>,
+    ) -> (StatusOp<crate::engine::UnrealEngineProvider>, RepoStatusRef) {
+        let mut app_config = AppConfig::new(crate::APP_NAME);
+        app_config.repo_path = repo_path.to_str().expect("utf8 repo path").to_string();
+        app_config.target_branch = target_branch.to_string();
+        let app_config: AppConfigRef = Arc::new(RwLock::new(app_config));
+
+        let repo_config = RepoConfig {
+            target_branches,
+            ..Default::default()
+        };
+        let repo_config: RepoConfigRef = Arc::new(RwLock::new(repo_config));
+
+        let engine = crate::engine::UnrealEngineProvider::new_from_config(
+            app_config.read().clone(),
+            repo_config.read().clone(),
+        );
+
+        let repo_status: RepoStatusRef = Arc::new(RwLock::new(RepoStatus::new()));
+
+        let status_op = StatusOp {
+            git_client,
+            github_username: "test_user".to_string(),
+            repo_status: repo_status.clone(),
+            app_config,
+            repo_config,
+            engine,
+            aws_client: None,
+            storage: None,
+            allow_offline_communication: false,
+            skip_display_names: true,
+            skip_engine_update: true,
+        };
+
+        (status_op, repo_status)
+    }
+
+    #[tokio::test]
+    async fn blocked_path_gets_blocked_status() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join("Content/Foo.uasset"), "v1\n").unwrap();
+
+        let target_branches = vec![
+            TargetBranchConfig {
+                name: "main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec!["**/*.uasset".to_string()],
+            },
+            TargetBranchConfig {
+                name: "content-main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec![],
+            },
+        ];
+        let (status_op, _repo_status) = build_status_op(git, dir.path(), "main", target_branches);
+
+        let status = status_op.run().await.expect("status run");
+        let file = status
+            .untracked_files
+            .get("Content/Foo.uasset")
+            .expect("file present in untracked files");
+        assert_eq!(file.submit_status, SubmitStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn deleted_blocked_path_is_not_blocked() {
+        // A blocked pattern that also covers a non-lockable extension, so a
+        // deleted match falls all the way through the chain to `Ok` rather
+        // than being intercepted by the (unrelated, pre-existing) lockable
+        // asset-checkout branch — keeping this test's assertion about
+        // exactly one thing: deletions are exempt from blocking.
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/Removed.dat";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "doomed\n").unwrap();
+        git.run(&["add", path], git::Opts::default()).await.unwrap();
+        git.run(&["commit", "-qm", "add doomed file"], git::Opts::default())
+            .await
+            .unwrap();
+        fs::remove_file(dir.path().join(path)).unwrap();
+
+        let target_branches = vec![TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: false,
+            blocked_file_globs: vec!["**/*.uasset".to_string(), "**/*.dat".to_string()],
+        }];
+        let (status_op, _repo_status) = build_status_op(git, dir.path(), "main", target_branches);
+
+        let status = status_op.run().await.expect("status run");
+        let file = status
+            .modified_files
+            .get(path)
+            .expect("deleted file present in modified files");
+        assert_eq!(file.state, FileState::Deleted, "fixture sanity check");
+        assert_eq!(
+            file.submit_status,
+            SubmitStatus::Ok,
+            "a deleted file matching a blocked glob must remain submittable"
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_wins_over_unmerged() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/mm.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "base\n").unwrap();
+        git.run(&["add", path], git::Opts::default()).await.unwrap();
+        git.run(&["commit", "-qm", "add base"], git::Opts::default())
+            .await
+            .unwrap();
+
+        git.run(&["checkout", "-q", "-b", "feature-a"], git::Opts::default())
+            .await
+            .unwrap();
+        fs::write(dir.path().join(path), "a-version\n").unwrap();
+        git.run(&["commit", "-aqm", "feature a edit"], git::Opts::default())
+            .await
+            .unwrap();
+
+        git.run(&["checkout", "-q", "main"], git::Opts::default())
+            .await
+            .unwrap();
+        git.run(&["checkout", "-q", "-b", "feature-b"], git::Opts::default())
+            .await
+            .unwrap();
+        fs::write(dir.path().join(path), "b-version\n").unwrap();
+        git.run(&["commit", "-aqm", "feature b edit"], git::Opts::default())
+            .await
+            .unwrap();
+
+        git.run(&["checkout", "-q", "feature-a"], git::Opts::default())
+            .await
+            .unwrap();
+        // Expected to fail with a real conflict — we want the resulting
+        // conflicted working tree, not a successful merge.
+        let _ = git
+            .run(&["merge", "feature-b", "--no-edit"], git::Opts::default())
+            .await;
+
+        let target_branches = vec![TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: false,
+            blocked_file_globs: vec!["**/*.uasset".to_string()],
+        }];
+        let (status_op, _repo_status) = build_status_op(git, dir.path(), "main", target_branches);
+
+        let status = status_op.run().await.expect("status run");
+        let file = status
+            .modified_files
+            .get(path)
+            .expect("conflicted file present in modified files");
+        assert_eq!(
+            file.state,
+            FileState::Unmerged,
+            "fixture sanity check: file must actually be unmerged"
+        );
+        assert_eq!(file.submit_status, SubmitStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn blocked_wins_over_conflicted() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/Foo.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v1\n").unwrap();
+        git.run(&["add", path], git::Opts::default()).await.unwrap();
+        git.run(&["commit", "-qm", "add foo v1"], git::Opts::default())
+            .await
+            .unwrap();
+        git.run(&["push", "-q", "origin", "main"], git::Opts::default())
+            .await
+            .unwrap();
+
+        // Move local `main` back a commit so the file diverges from
+        // `origin/main`, then recreate it locally with different content as
+        // an untracked file — the shape `get_upstream_conflicts` looks for
+        // (a path that's both modified upstream and present locally).
+        git.run(&["reset", "-q", "--hard", "HEAD~1"], git::Opts::default())
+            .await
+            .unwrap();
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v2\n").unwrap();
+
+        let target_branches = vec![TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: false,
+            blocked_file_globs: vec!["**/*.uasset".to_string()],
+        }];
+        let (status_op, _repo_status) = build_status_op(git, dir.path(), "main", target_branches);
+
+        let status = status_op.run().await.expect("status run");
+        assert!(
+            status.conflicts.iter().any(|p| p == path),
+            "fixture sanity check: file must actually be an upstream conflict, got {:?}",
+            status.conflicts
+        );
+        let file = status
+            .untracked_files
+            .get(path)
+            .expect("file present in untracked files");
+        assert_eq!(file.submit_status, SubmitStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn blocked_wins_over_checkout_required() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/NeedsCheckout.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v1\n").unwrap();
+
+        let target_branches = vec![TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: false,
+            blocked_file_globs: vec!["**/*.uasset".to_string()],
+        }];
+        let (status_op, _repo_status) = build_status_op(git, dir.path(), "main", target_branches);
+
+        let status = status_op.run().await.expect("status run");
+        let file = status
+            .untracked_files
+            .get(path)
+            .expect("file present in untracked files");
+        assert_eq!(file.submit_status, SubmitStatus::Blocked);
+        assert_ne!(file.submit_status, SubmitStatus::CheckoutRequired);
+    }
+
+    #[tokio::test]
+    async fn blocked_only_on_configured_branch() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/Foo.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v1\n").unwrap();
+
+        let target_branches = vec![
+            TargetBranchConfig {
+                name: "main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec!["**/*.uasset".to_string()],
+            },
+            TargetBranchConfig {
+                name: "content-main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec![],
+            },
+        ];
+
+        let (status_op, _repo_status) =
+            build_status_op(git.clone(), dir.path(), "main", target_branches.clone());
+        let status = status_op.run().await.expect("status run on main");
+        let file = status
+            .untracked_files
+            .get(path)
+            .expect("file present on main");
+        assert_eq!(file.submit_status, SubmitStatus::Blocked);
+
+        git.run(&["checkout", "-q", "content-main"], git::Opts::default())
+            .await
+            .unwrap();
+        let (status_op, _repo_status) =
+            build_status_op(git, dir.path(), "content-main", target_branches);
+        let status = status_op.run().await.expect("status run on content-main");
+        let file = status
+            .untracked_files
+            .get(path)
+            .expect("file present on content-main");
+        assert_ne!(file.submit_status, SubmitStatus::Blocked);
+    }
+
+    #[tokio::test]
+    async fn unknown_target_branch_degrades_to_nothing_blocked() {
+        let (dir, _remote, git) = make_test_repo_with_remote().await;
+        let path = "Content/Foo.uasset";
+        fs::create_dir_all(dir.path().join("Content")).unwrap();
+        fs::write(dir.path().join(path), "v1\n").unwrap();
+
+        // Check out a branch whose name mirrors the (unconfigured) target
+        // branch, so the ahead/behind lookup — which only runs when the
+        // checked-out branch differs from the target branch — doesn't need
+        // a matching remote ref. This test is only about
+        // `blocked_globs_for_branch` degrading safely for an unknown
+        // branch, not about ahead/behind accounting.
+        git.run(&["checkout", "-q", "-b", "release"], git::Opts::default())
+            .await
+            .unwrap();
+
+        let target_branches = vec![
+            TargetBranchConfig {
+                name: "main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec!["**/*.uasset".to_string()],
+            },
+            TargetBranchConfig {
+                name: "content-main".to_string(),
+                uses_merge_queue: false,
+                blocked_file_globs: vec![],
+            },
+        ];
+        let (status_op, _repo_status) =
+            build_status_op(git, dir.path(), "release", target_branches);
+
+        let status = status_op
+            .run()
+            .await
+            .expect("status run must not error for an unconfigured target branch");
+        let file = status
+            .untracked_files
+            .get(path)
+            .expect("file present in untracked files");
+        assert_ne!(file.submit_status, SubmitStatus::Blocked);
+    }
 
     #[test]
     fn test_find_dll_commit() {

--- a/friendshipper/src-tauri/tests/common/mod.rs
+++ b/friendshipper/src-tauri/tests/common/mod.rs
@@ -375,8 +375,34 @@ async fn initialize_test_repo() {
     }
 }
 
+/// The `RepoConfig` used by `setup()` when a test has no opinion about it.
+fn default_test_repo_config() -> RepoConfig {
+    let remote_path: PathBuf = TEST_DIR.join("test-remote");
+    RepoConfig {
+        uproject_path: build_uproject_path(&remote_path)
+            .into_os_string()
+            .into_string()
+            .unwrap(),
+        trunk_branch: "main".to_string(),
+        git_hooks_path: None,
+        ..Default::default()
+    }
+}
+
 pub async fn setup(
     schema_version: StorageSchemaVersion,
+) -> anyhow::Result<TestServer<UnrealEngineProvider>> {
+    setup_with_repo_config(schema_version, default_test_repo_config()).await
+}
+
+/// Same as `setup()`, but lets a test supply its own `RepoConfig` — for
+/// example one with `blockedFileGlobs` set on a `TargetBranchConfig`, to
+/// cross-validate the config-to-wire path for blocked-file submit status
+/// through the real HTTP status endpoint rather than only in-process.
+#[allow(dead_code)]
+pub async fn setup_with_repo_config(
+    schema_version: StorageSchemaVersion,
+    repo_config: RepoConfig,
 ) -> anyhow::Result<TestServer<UnrealEngineProvider>> {
     info!("Setting up test server");
     initialize_test_repo().await;
@@ -453,16 +479,7 @@ pub async fn setup(
     });
 
     info!("Created longtail logger. Creating repo config.");
-    let remote_path: PathBuf = TEST_DIR.join("test-remote");
-    let repo_config = Arc::new(RwLock::new(RepoConfig {
-        uproject_path: build_uproject_path(&remote_path)
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-        trunk_branch: "main".to_string(),
-        git_hooks_path: None,
-        ..Default::default()
-    }));
+    let repo_config = Arc::new(RwLock::new(repo_config));
 
     info!("Created app state. Creating artifact storage.");
     let dynamic_config = Arc::new(RwLock::new(DynamicConfig {

--- a/friendshipper/src-tauri/tests/repo.rs
+++ b/friendshipper/src-tauri/tests/repo.rs
@@ -3,7 +3,9 @@ use tokio::{fs, io::AsyncWriteExt};
 use tracing::info;
 
 use ethos_core::middleware::nonce::{NONCE, NONCE_HEADER};
+use ethos_core::types::config::{RepoConfig, TargetBranchConfig};
 use ethos_core::types::repo::FileState;
+use ethos_core::types::repo::SubmitStatus;
 use ethos_core::types::repo::{PushRequest, RepoStatus};
 
 mod common;
@@ -139,6 +141,57 @@ async fn test_new_file_workflow() -> Result<(), Box<dyn std::error::Error>> {
     assert!(status.untracked_files.is_empty());
     assert!(status.modified_files.contains("test.txt"));
     assert_eq!(status.commits_ahead, 0);
+
+    server.shutdown().await;
+
+    common::teardown().await;
+
+    Ok(())
+}
+
+// Cross-validates the blocked-file-globs feature through the real HTTP
+// status endpoint — config load -> `StatusOp` -> JSON wire format -- rather
+// than only in-process, complementing the in-crate unit tests in
+// `src/repo/operations/status.rs`.
+#[test(tokio::test(flavor = "multi_thread"))]
+async fn test_status_endpoint_reports_blocked_files() -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting test_status_endpoint_reports_blocked_files");
+    let repo_config = RepoConfig {
+        trunk_branch: "main".to_string(),
+        target_branches: vec![TargetBranchConfig {
+            name: "main".to_string(),
+            uses_merge_queue: false,
+            blocked_file_globs: vec!["**/*.uasset".to_string()],
+        }],
+        ..Default::default()
+    };
+    let mut server = common::setup_with_repo_config("v1".parse().unwrap(), repo_config).await?;
+
+    let content_dir = common::TEST_DIR.join("test-local").join("Content");
+    fs::create_dir_all(&content_dir).await?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(content_dir.join("Blocked.uasset"))
+        .await?;
+    file.write_all(b"blocked content").await?;
+    file.sync_all().await?;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("http://localhost:8585/repo/status")
+        .header(NONCE_HEADER, NONCE.to_string())
+        .send()
+        .await?;
+
+    let status = resp.json::<RepoStatus>().await?;
+    let file_info = status
+        .untracked_files
+        .into_iter()
+        .find(|f| f.path == "Content/Blocked.uasset")
+        .expect("blocked file present in status response");
+    assert_eq!(file_info.submit_status, SubmitStatus::Blocked);
 
     server.shutdown().await;
 

--- a/friendshipper/src/lib/types.ts
+++ b/friendshipper/src/lib/types.ts
@@ -99,6 +99,7 @@ export interface PlaytestProfile {
 export interface TargetBranchConfig {
 	name: string;
 	usesMergeQueue: boolean;
+	blockedFileGlobs: string[];
 }
 
 export interface PromoteBuildShard {

--- a/friendshipper/src/routes/source/submit/+page.svelte
+++ b/friendshipper/src/routes/source/submit/+page.svelte
@@ -255,7 +255,9 @@
 		typeof $commitMessage === 'string'
 			? $commitMessage
 			: `${$commitMessage.type}(${$commitMessage.scope}): ${$commitMessage.message}`;
-	$: hasUnsubmittableFiles = $selectedFiles.some((file) => file.submitStatus !== SubmitStatus.Ok);
+	$: hasUnsubmittableFiles = $selectedFiles.some(
+		(file) => file.submitStatus !== SubmitStatus.Ok && file.submitStatus !== SubmitStatus.Unknown
+	);
 	$: canSubmit =
 		$selectedFiles.length > 0 &&
 		get(commitMessage) !== '' &&


### PR DESCRIPTION
## Summary

A project can now declare, per entry in `targetBranches` in its committed `friendshipper.yaml`, which paths must never be submitted to that branch:

```yaml
targetBranches:
  - name: main
    usesMergeQueue: true
    blockedFileGlobs:
      - "**/*.uasset"
      - "**/*.umap"
```

Motivating case: a repo that splits code and content across branches. Quick submit is deliberately frictionless — it stages, commits, cuts a branch, pushes, and opens a PR in one action — so a wrong-branch submit is cheap to make and expensive to unwind once a merge queue has accepted it.

- Enforcement is authoritative in `SubmitOp` and surfaced early in the UI via a new `SubmitStatus::Blocked`. Blocked files render red with an explanatory tooltip and disable Submit.
- The gate runs **before** the pre-submit snapshot and before branch creation, so a blocked submit **mutates no git state**.
- Deletions are never blocked — removing a wrongly-committed asset is the cleanup path this feature implies teams will need.
- The field is `#[serde(default)]`, so every existing `friendshipper.yaml` keeps working untouched.

## ⚠️ Reviewer attention — unresolved external contract

`friendshipper/src-tauri/src/engine/unreal/provider.rs` POSTs the full `RepoStatus` — including every `File.submitStatus` — to the Unreal editor plugin at `localhost:8091`. That C++ consumer lives **outside this repo**, and it will now start receiving the string `"Blocked"`.

**This has not been verified.** If the plugin treats unrecognized enum strings as an error, editor integration could degrade for every user the moment they touch a blocked file, and **no test in this repository can catch it**. If it turns out to be strict, the fix is to normalize `Blocked` out of that one payload and keep the variant internal to Friendshipper.

## Glob semantics worth knowing

`globset`, with `literal_separator` and case-insensitivity set explicitly so Windows and Linux behave identically:

| Pattern | Matches |
|---|---|
| `**/*.uasset` | any depth |
| `Content/*.uasset` | direct children of `Content/` only |
| `*.uasset` | repository root only |

That last row is a trap, so **config load warns** on patterns that will silently under-match (no `/` and no `**`) and on patterns using backslash separators — a `Content\Chars\**` pattern works on Windows but silently protects nothing on Linux/macOS. Invalid patterns are skipped and logged rather than failing config load, which would brick app startup for every user of the project.

## Also in this change

- **`SubmitStatus` tolerates unknown values on deserialize.** It is persisted to `changesets.json` and read back with a plain `serde_json::from_str`, so without this a user who downgrades after the new variant is written would lose *every* changeset to one hard error — not a per-file degrade.
- **The per-file submit rejection now names the offending files and reasons** instead of directing the user to the log. Truncated to 10 paths since it renders in a toast.
- **`usesMergeQueue` gains a serde default of `true`**, matching `Default::default()`. It previously had none, so an entry omitting it failed app startup for every user of that project.
- **CI now runs `cargo test --lib --bins -p <app>`** instead of `--bin <app>`, which executed only the bin target — 1 test — and skipped all 56 lib tests. Pre-existing gap, but it made this PR's own tests invisible to CI.

## Scope note

This is a **guardrail against accidental submits, not an enforcement boundary**. A user with a terminal can still push directly. Projects wanting a hard guarantee should also use branch protection or a pre-commit hook via the existing `gitHooksPath` mechanism.

Allow-lists and `!` negation patterns are out of scope.

## Test plan

- [x] `cargo fmt --all --check` and `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --release -p ethos-core` — 71 passed
- [x] `cargo test --release --lib --bins -p friendshipper` — 57 passed (incl. 8 enforcement tests against real git repos)
- [x] `yarn lint` / eslint clean on all touched frontend files
- [x] `yarn tauri:build` succeeds
- [x] **Exercised in a running app** against a real project repo. Verified live via the status endpoint: a file matching the glob returned `submitStatus='Blocked'` while an adjacent non-matching `.uasset` returned `'CheckoutRequired'` — confirming both that `Blocked` takes precedence over the lockable-asset check and that the glob is selective. Red row and tooltip confirmed visually.
- [x] Cross-platform considered — case-insensitivity and separator handling set explicitly; CI builds Linux + Windows
- [ ] **Unreal plugin behavior on the new `submitStatus` string — see warning above**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
