### PR TITLE
feat(friendshipper): add a main-first build picker to the playtest modal

### DIFF
--- a/friendshipper/src-tauri/src/builds/router.rs
+++ b/friendshipper/src-tauri/src/builds/router.rs
@@ -465,11 +465,47 @@ pub struct CommitWorkflowInfo {
 pub struct GetWorkflowsParams {
     #[serde(default)]
     pub engine: bool,
+    pub project: Option<String>,
 }
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct GetWorkflowsResponse {
     pub commits: Vec<CommitWorkflowInfo>,
+}
+
+fn resolve_workflow_project(
+    params_project: Option<String>,
+    selected_artifact_project: Option<String>,
+    engine: bool,
+    engine_repo_url: &str,
+) -> anyhow::Result<String> {
+    let mut project = if let Some(project) = params_project {
+        project
+    } else {
+        selected_artifact_project
+            .context("Project not configured. Repo may still be initializing.")?
+    };
+
+    if engine && !engine_repo_url.is_empty() {
+        // `engine_repo_url` is free-form config, so walk from the right and skip empty segments
+        // rather than indexing: a trailing slash still resolves, and a value with no '/' falls
+        // through to the param/config project instead of panicking on an underflowed index.
+        let mut segments = engine_repo_url.rsplit('/').filter(|s| !s.is_empty());
+
+        let repo_name = segments
+            .next()
+            .map(|name| name.trim_end_matches(".git"))
+            .filter(|name| !name.is_empty());
+        let repo_owner = segments.next();
+
+        if let (Some(owner), Some(name)) = (repo_owner, repo_name) {
+            let owner = owner.to_lowercase();
+            let name = name.to_lowercase();
+            project = format!("{owner}-{name}");
+        }
+    }
+
+    Ok(project)
 }
 
 async fn get_workflows<T>(
@@ -482,21 +518,13 @@ where
     let kube_client = ensure_kube_client(state.kube_client.read().clone())?;
 
     let config = state.app_config.read().clone();
-    let mut selected_artifact_project = config
-        .selected_artifact_project
-        .context("Project not configured. Repo may still be initializing.")?;
 
-    if params.engine && !config.engine_repo_url.is_empty() {
-        let parts = config.engine_repo_url.split('/').collect::<Vec<&str>>();
-        let repo_owner = parts.get(parts.len() - 2).unwrap().to_lowercase();
-        let repo_name = parts
-            .last()
-            .unwrap()
-            .trim_end_matches(".git")
-            .to_lowercase();
-
-        selected_artifact_project = format!("{repo_owner}-{repo_name}");
-    }
+    let selected_artifact_project = resolve_workflow_project(
+        params.project.clone(),
+        config.selected_artifact_project.clone(),
+        params.engine,
+        &config.engine_repo_url,
+    )?;
 
     let workflows = kube_client
         .get_workflows(&selected_artifact_project)
@@ -778,4 +806,81 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn param_project_wins_over_config() {
+        let result = resolve_workflow_project(
+            Some("param-project".to_string()),
+            Some("config-project".to_string()),
+            false,
+            "",
+        )
+        .unwrap();
+        assert_eq!(result, "param-project");
+    }
+
+    #[test]
+    fn falls_back_to_config_project() {
+        let result =
+            resolve_workflow_project(None, Some("config-project".to_string()), false, "").unwrap();
+        assert_eq!(result, "config-project");
+    }
+
+    #[test]
+    fn errors_when_no_project_available() {
+        assert!(resolve_workflow_project(None, None, false, "").is_err());
+    }
+
+    #[test]
+    fn engine_repo_overrides_everything() {
+        let result = resolve_workflow_project(
+            Some("param-project".to_string()),
+            Some("config-project".to_string()),
+            true,
+            "https://github.com/BelieverCo/GamePrototypeMP.git",
+        )
+        .unwrap();
+        assert_eq!(result, "believerco-gameprototypemp");
+    }
+
+    #[test]
+    fn engine_flag_without_repo_url_does_not_override() {
+        let result = resolve_workflow_project(
+            Some("param-project".to_string()),
+            Some("config-project".to_string()),
+            true,
+            "",
+        )
+        .unwrap();
+        assert_eq!(result, "param-project");
+    }
+
+    #[test]
+    fn engine_repo_url_without_any_slash_falls_through_instead_of_panicking() {
+        let result = resolve_workflow_project(
+            Some("param-project".to_string()),
+            Some("config-project".to_string()),
+            true,
+            "GamePrototypeMP",
+        )
+        .unwrap();
+        assert_eq!(result, "param-project");
+    }
+
+    #[test]
+    fn engine_repo_url_with_trailing_slash_still_resolves() {
+        let result = resolve_workflow_project(
+            Some("param-project".to_string()),
+            Some("config-project".to_string()),
+            true,
+            "https://github.com/BelieverCo/GamePrototypeMP/",
+        )
+        .unwrap();
+        assert_eq!(result, "believerco-gameprototypemp");
+    }
 }

--- a/friendshipper/src-tauri/src/command.rs
+++ b/friendshipper/src-tauri/src/command.rs
@@ -509,15 +509,18 @@ pub async fn reset_repo_to_commit(
 pub async fn get_workflows(
     state: tauri::State<'_, State>,
     engine: bool,
+    project: Option<String>,
 ) -> Result<GetWorkflowsResponse, TauriError> {
-    let res = state
+    let mut req = state
         .client
-        .get(format!(
-            "{}/builds/workflows?engine={}",
-            state.server_url, engine
-        ))
-        .send()
-        .await?;
+        .get(format!("{}/builds/workflows", state.server_url))
+        .query(&[("engine", engine)]);
+
+    if let Some(project) = project {
+        req = req.query(&[("project", project)]);
+    }
+
+    let res = req.send().await?;
 
     if is_error_status(res.status()) {
         return Err(create_tauri_error(res).await);

--- a/friendshipper/src/lib/builds.ts
+++ b/friendshipper/src/lib/builds.ts
@@ -23,8 +23,10 @@ export const wipeClientData = async (): Promise<void> => invoke('wipe_client_dat
 
 export const resetLongtail = async (): Promise<void> => invoke('reset_longtail');
 
-export const getWorkflows = async (engine: boolean = false): Promise<GetWorkflowsResponse> =>
-	invoke('get_workflows', { engine });
+export const getWorkflows = async (
+	engine: boolean = false,
+	project?: string
+): Promise<GetWorkflowsResponse> => invoke('get_workflows', { engine, project });
 
 export const getWorkflowNodes = async (name: string): Promise<Workflow> =>
 	invoke('get_workflow_nodes', { name });

--- a/friendshipper/src/lib/components/playtests/BuildPicker.svelte
+++ b/friendshipper/src/lib/components/playtests/BuildPicker.svelte
@@ -1,0 +1,497 @@
+<script lang="ts">
+	import {
+		ChevronDownOutline,
+		ChevronLeftOutline,
+		ChevronRightOutline
+	} from 'flowbite-svelte-icons';
+	import { tick } from 'svelte';
+	import type { ArtifactEntry, CommitWorkflowInfo } from '$lib/types';
+	import { cleanBranchName, formatRelativeAge, isTrunkBuild } from '$lib/utils';
+
+	export let versions: ArtifactEntry[];
+	export let selectedSha: string;
+	export let workflowMap: Map<string, CommitWorkflowInfo>;
+	export let trunkBranch: string;
+	export let currentUserDisplayName: string;
+	export let originalSha: string | null = null;
+	// Rendered in the panel footer; beside the summary button a long message pushes it out of view.
+	export let onManualEntry: (() => void) | null = null;
+
+	// Sentinel key for the unknown group; `cleanBranchName` never produces this name.
+	const UNKNOWN_SECTION = '__unknown__';
+
+	interface Grouped {
+		trunk: ArtifactEntry[];
+		branches: Map<string, ArtifactEntry[]>; // key = cleaned branch name, case-sensitive
+		unknown: ArtifactEntry[];
+	}
+
+	type BuildTone = 'trunk' | 'branch' | 'unknown';
+
+	interface SummaryState {
+		label: string;
+		tone: string;
+	}
+
+	let expanded = false;
+	let activePane: 'main' | 'branches' = 'main';
+	let expandedBranches: Set<string> = new Set();
+
+	const groupVersions = (
+		entries: ArtifactEntry[],
+		wfMap: Map<string, CommitWorkflowInfo>,
+		trunk: string
+	): Grouped => {
+		const trunkList: ArtifactEntry[] = [];
+		const branchMap = new Map<string, ArtifactEntry[]>();
+		const unknownList: ArtifactEntry[] = [];
+
+		for (const entry of entries) {
+			const branch = wfMap.get(entry.commit)?.branch;
+			if (!branch) {
+				unknownList.push(entry);
+			} else if (isTrunkBuild(branch, trunk)) {
+				trunkList.push(entry);
+			} else {
+				const branchName = cleanBranchName(branch);
+				const existing = branchMap.get(branchName);
+				if (existing) {
+					existing.push(entry);
+				} else {
+					branchMap.set(branchName, [entry]);
+				}
+			}
+		}
+
+		const byRecencyThenSha = (a: ArtifactEntry, b: ArtifactEntry): number =>
+			b.lastModified - a.lastModified || (a.commit < b.commit ? -1 : 1);
+
+		trunkList.sort(byRecencyThenSha);
+		unknownList.sort(byRecencyThenSha);
+		for (const list of branchMap.values()) {
+			list.sort(byRecencyThenSha);
+		}
+
+		return { trunk: trunkList, branches: branchMap, unknown: unknownList };
+	};
+
+	// `commit` is `Option<String>` in Rust but `string` in types.ts; a throw inside the keyed
+	// `{#each}` would blank the whole panel rather than skip one row.
+	const shortSha = (sha: string | null | undefined): string => (sha ?? '').substring(0, 8);
+
+	// Both sides must be non-empty — `'' === ''` would badge every branch "yours".
+	const isMine = (
+		entries: ArtifactEntry[],
+		wfMap: Map<string, CommitWorkflowInfo>,
+		user: string
+	): boolean => {
+		const normalizedUser = user.trim().toLowerCase();
+		if (!normalizedUser) return false;
+		return entries.some((e) => {
+			const pusher = wfMap.get(e.commit)?.pusher?.trim().toLowerCase();
+			return !!pusher && pusher === normalizedUser;
+		});
+	};
+
+	const orderedBranchNames = (
+		branchMap: Map<string, ArtifactEntry[]>,
+		wfMap: Map<string, CommitWorkflowInfo>,
+		user: string
+	): string[] =>
+		Array.from(branchMap.entries())
+			.sort(([aName, aEntries], [bName, bEntries]) => {
+				const aMine = isMine(aEntries, wfMap, user);
+				const bMine = isMine(bEntries, wfMap, user);
+				if (aMine !== bMine) return aMine ? -1 : 1;
+
+				// Entry arrays are already sorted newest-first by groupVersions.
+				const aRecency = aEntries[0].lastModified;
+				const bRecency = bEntries[0].lastModified;
+				if (aRecency !== bRecency) return bRecency - aRecency;
+
+				return aName.toLowerCase().localeCompare(bName.toLowerCase());
+			})
+			.map(([branchName]) => branchName);
+
+	// Always via `isTrunkBuild`, so this and PlaytestModal's default selection cannot drift apart.
+	const classifyBuild = (
+		sha: string,
+		wfMap: Map<string, CommitWorkflowInfo>,
+		trunk: string
+	): BuildTone => {
+		const branch = wfMap.get(sha)?.branch;
+		if (!branch) return 'unknown';
+		return isTrunkBuild(branch, trunk) ? 'trunk' : 'branch';
+	};
+
+	const toneClass = (tone: BuildTone): string => {
+		if (tone === 'trunk') return 'text-green-400';
+		if (tone === 'branch') return 'text-blue-400';
+		return 'text-gray-400';
+	};
+
+	const summaryState = (
+		entries: ArtifactEntry[],
+		sha: string,
+		wfMap: Map<string, CommitWorkflowInfo>,
+		trunk: string
+	): SummaryState => {
+		// Sha before emptiness: a pinned selection must still show when the build list fails to load.
+		if (sha) {
+			if (!entries.some((e) => e.commit === sha)) {
+				return { label: `Not in list: ${shortSha(sha)}`, tone: 'text-amber-400' };
+			}
+			return { label: shortSha(sha), tone: toneClass(classifyBuild(sha, wfMap, trunk)) };
+		}
+		if (entries.length === 0) return { label: 'No builds available', tone: 'text-gray-400' };
+		return { label: 'No build selected', tone: 'text-gray-400' };
+	};
+
+	// `formatRelativeAge` returns an absolute date past ~30 days, which "is {age} old" would mangle.
+	const RELATIVE_AGE_PATTERN = /^\d+[mhd]$/;
+
+	const trunkAnchor = (newest: ArtifactEntry | undefined, trunk: string): string => {
+		if (!newest) return `no builds on ${trunk}`;
+		const age = formatRelativeAge(newest.lastModified);
+		if (age === 'just now') return `${trunk} built just now`;
+		if (RELATIVE_AGE_PATTERN.test(age)) return `${trunk} is ${age} old`;
+		return `${trunk} last built ${age}`;
+	};
+
+	$: grouped = groupVersions(versions, workflowMap, trunkBranch);
+	$: branchOrder = orderedBranchNames(grouped.branches, workflowMap, currentUserDisplayName);
+	$: selectedEntry = versions.find((v) => v.commit === selectedSha);
+	$: originalEntry = versions.find((v) => v.commit === originalSha);
+	$: summary = summaryState(versions, selectedSha, workflowMap, trunkBranch);
+	// Zero exactly when there is nothing at all behind the branch rail.
+	$: branchSectionCount = grouped.branches.size + (grouped.unknown.length > 0 ? 1 : 0);
+	$: mainRailAnchor = trunkAnchor(grouped.trunk[0], trunkBranch);
+
+	const collapsePanel = () => {
+		expanded = false;
+		activePane = 'main';
+		expandedBranches = new Set();
+	};
+
+	// Reseeded on every open, so the user's own sections start expanded each time.
+	const expandPanel = () => {
+		expanded = true;
+		expandedBranches = new Set(
+			Array.from(grouped.branches.entries())
+				.filter(([, entries]) => isMine(entries, workflowMap, currentUserDisplayName))
+				.map(([branchName]) => branchName)
+		);
+	};
+
+	const handleManualEntry = () => {
+		collapsePanel();
+		onManualEntry?.();
+	};
+
+	const toggleExpanded = () => {
+		if (expanded) {
+			collapsePanel();
+		} else {
+			expandPanel();
+		}
+	};
+
+	// Swapping panes unmounts the rail that was just clicked, dropping focus to document.body.
+	// Move focus to the rail replacing it.
+	let mainRailEl: HTMLButtonElement | null = null;
+	let branchRailEl: HTMLButtonElement | null = null;
+
+	// Named handlers: an inline arrow returning an assignment trips `no-return-assign`.
+	const showBranchesPane = () => {
+		activePane = 'branches';
+		void tick().then(() => {
+			mainRailEl?.focus();
+		});
+	};
+
+	const showMainPane = () => {
+		activePane = 'main';
+		void tick().then(() => {
+			branchRailEl?.focus();
+		});
+	};
+
+	const toggleBranch = (branchName: string) => {
+		const next = new Set(expandedBranches);
+		if (next.has(branchName)) {
+			next.delete(branchName);
+		} else {
+			next.add(branchName);
+		}
+		expandedBranches = next; // reassign — Svelte does not track Set mutation
+	};
+
+	const selectEntry = (sha: string) => {
+		selectedSha = sha;
+		collapsePanel();
+	};
+
+	const selectOriginal = () => {
+		if (originalSha) selectEntry(originalSha);
+	};
+
+	const messageFor = (sha: string): string => workflowMap.get(sha)?.message ?? '';
+
+	// Capture on window, not bubble on our root: swapping panes drops focus to document.body, so a
+	// root handler stops firing. Capture also runs before flowbite Modal's Escape handler, which
+	// would otherwise close the whole dialog. Left untouched while collapsed.
+	const handleWindowKeydown = (event: KeyboardEvent) => {
+		if (!expanded || event.key !== 'Escape') return;
+		event.preventDefault();
+		event.stopPropagation();
+		collapsePanel();
+	};
+</script>
+
+<svelte:window on:keydown|capture={handleWindowKeydown} />
+
+<div class="w-full">
+	<!-- Not disabled when the list is empty: the panel must still open to reach the manual-entry
+	     footer. No aria-label either - it would override the button's text and hide the sha. -->
+	<button
+		type="button"
+		aria-expanded={expanded}
+		class="flex w-full flex-row items-center gap-2 rounded-lg border border-secondary-600 px-2.5 py-1.5 text-left text-xs dark:border-space-800 bg-secondary-700 dark:bg-space-900"
+		on:click={toggleExpanded}
+	>
+		<span class="shrink-0 font-mono {summary.tone}">{summary.label}</span>
+		{#if selectedEntry}
+			<span class="min-w-0 flex-1 truncate text-gray-300">{messageFor(selectedEntry.commit)}</span>
+			<span class="w-12 shrink-0 text-right text-gray-400">
+				{formatRelativeAge(selectedEntry.lastModified)}
+			</span>
+		{:else}
+			<span class="min-w-0 flex-1" />
+		{/if}
+		<ChevronDownOutline size="xs" class="shrink-0 text-gray-400" />
+	</button>
+
+	{#if expanded}
+		<div
+			class="mt-1 flex flex-row overflow-hidden rounded-lg border border-secondary-600 dark:border-space-800 bg-secondary-800 dark:bg-space-950"
+		>
+			{#if activePane === 'main'}
+				<div class="max-h-64 min-w-0 flex-1 overflow-y-auto p-1">
+					{#if originalSha !== null && originalSha !== selectedSha}
+						<button
+							type="button"
+							class="mb-1 flex w-full flex-row items-center gap-2 rounded border-b border-secondary-600 px-2 py-1 text-left text-xs dark:border-space-800 hover:bg-secondary-700 dark:hover:bg-space-900"
+							on:click={selectOriginal}
+						>
+							<span class="shrink-0 rounded bg-space-800 px-1 text-[10px] uppercase text-gray-300">
+								Current
+							</span>
+							<span class="shrink-0 font-mono text-gray-200">{shortSha(originalSha)}</span>
+							<span class="min-w-0 flex-1 truncate text-gray-400">{messageFor(originalSha)}</span>
+							<span class="w-12 shrink-0 text-right text-gray-500">
+								{originalEntry ? formatRelativeAge(originalEntry.lastModified) : ''}
+							</span>
+						</button>
+					{/if}
+
+					{#if grouped.trunk.length === 0}
+						<div class="px-2 py-1 text-xs italic text-gray-500">
+							No builds on {trunkBranch} yet.
+						</div>
+					{:else}
+						{#each grouped.trunk as entry (entry.key)}
+							{@const isSelected = entry.commit === selectedSha}
+							<!-- The ring marks the selection: the selected background matches every row's own
+							     hover background, so it alone vanishes under the pointer. -->
+							<button
+								type="button"
+								aria-current={isSelected ? 'true' : undefined}
+								class="flex w-full flex-row items-center gap-2 rounded px-2 py-1 text-left text-xs hover:bg-secondary-700 dark:hover:bg-space-900"
+								class:bg-secondary-700={isSelected}
+								class:dark:bg-space-900={isSelected}
+								class:ring-1={isSelected}
+								class:ring-inset={isSelected}
+								class:ring-primary-400={isSelected}
+								on:click={() => {
+									selectEntry(entry.commit);
+								}}
+							>
+								<span class="shrink-0 font-mono text-green-400">{shortSha(entry.commit)}</span>
+								<span class="min-w-0 flex-1 truncate text-gray-300">{messageFor(entry.commit)}</span
+								>
+								<span class="w-12 shrink-0 text-right text-gray-400">
+									{formatRelativeAge(entry.lastModified)}
+								</span>
+							</button>
+						{/each}
+					{/if}
+				</div>
+
+				<button
+					bind:this={branchRailEl}
+					type="button"
+					aria-label="Show branch builds ({branchSectionCount})"
+					class="flex w-[34px] shrink-0 flex-col items-center justify-center gap-1 border-l border-secondary-600 py-2 dark:border-space-800 hover:bg-secondary-700 dark:hover:bg-space-900"
+					on:click={showBranchesPane}
+				>
+					<ChevronRightOutline size="xs" class="text-blue-400" />
+					<span class="rail-label text-[10px] text-blue-400">Branches</span>
+					<span class="text-[10px] text-gray-400">{branchSectionCount}</span>
+				</button>
+			{:else}
+				<button
+					bind:this={mainRailEl}
+					type="button"
+					aria-label="Show {trunkBranch} builds — {mainRailAnchor}"
+					class="flex w-[34px] shrink-0 flex-col items-center justify-center gap-1 border-r border-secondary-600 py-2 dark:border-space-800 hover:bg-secondary-700 dark:hover:bg-space-900"
+					on:click={showMainPane}
+				>
+					<ChevronLeftOutline size="xs" class="text-green-400" />
+					<span class="rail-label text-[10px] text-green-400">{mainRailAnchor}</span>
+				</button>
+
+				<div class="max-h-64 min-w-0 flex-1 overflow-y-auto p-1">
+					{#if grouped.branches.size === 0 && grouped.unknown.length === 0}
+						<div class="px-2 py-1 text-xs italic text-gray-500">No branch builds found.</div>
+					{:else}
+						{#each branchOrder as branchName (branchName)}
+							{@const entries = grouped.branches.get(branchName) ?? []}
+							{@const mine = isMine(entries, workflowMap, currentUserDisplayName)}
+							<button
+								type="button"
+								aria-expanded={expandedBranches.has(branchName)}
+								class="flex w-full flex-row items-center gap-2 rounded px-2 py-1 text-left text-xs hover:bg-secondary-700 dark:hover:bg-space-900"
+								on:click={() => {
+									toggleBranch(branchName);
+								}}
+							>
+								<span class="shrink-0 text-gray-400">
+									{expandedBranches.has(branchName) ? '−' : '+'}
+								</span>
+								<span class="min-w-0 truncate font-medium text-blue-400">{branchName}</span>
+								{#if mine}
+									<span
+										class="shrink-0 rounded border border-primary-400/40 px-1 text-[9px] uppercase tracking-wide text-primary-400"
+									>
+										yours
+									</span>
+								{:else}
+									{@const pusher = workflowMap.get(entries[0]?.commit ?? '')?.pusher}
+									{#if pusher}
+										<span class="shrink-0 text-[10px] text-gray-400">@{pusher}</span>
+									{/if}
+								{/if}
+								<span class="ml-auto shrink-0 text-[10px] text-gray-400">{entries.length}</span>
+							</button>
+							{#if expandedBranches.has(branchName)}
+								<!-- Indented behind a hairline so builds read as belonging to their branch header. -->
+								<div class="mb-1 ml-3 border-l border-secondary-600 pl-1 dark:border-space-700">
+									{#each entries as entry (entry.key)}
+										{@const isSelected = entry.commit === selectedSha}
+										<button
+											type="button"
+											aria-current={isSelected ? 'true' : undefined}
+											class="flex w-full flex-row items-center gap-2 rounded px-2 py-1 text-left text-xs hover:bg-secondary-700 dark:hover:bg-space-900"
+											class:bg-secondary-700={isSelected}
+											class:dark:bg-space-900={isSelected}
+											class:ring-1={isSelected}
+											class:ring-inset={isSelected}
+											class:ring-primary-400={isSelected}
+											on:click={() => {
+												selectEntry(entry.commit);
+											}}
+										>
+											<span class="shrink-0 font-mono text-blue-400">
+												{shortSha(entry.commit)}
+											</span>
+											<span class="min-w-0 flex-1 truncate text-gray-300">
+												{messageFor(entry.commit)}
+											</span>
+											<span class="w-12 shrink-0 text-right text-gray-400">
+												{formatRelativeAge(entry.lastModified)}
+											</span>
+										</button>
+									{/each}
+								</div>
+							{/if}
+						{/each}
+
+						{#if grouped.unknown.length > 0}
+							<button
+								type="button"
+								aria-expanded={expandedBranches.has(UNKNOWN_SECTION)}
+								class="flex w-full flex-row items-center gap-2 rounded px-2 py-1 text-left text-xs hover:bg-secondary-700 dark:hover:bg-space-900"
+								on:click={() => {
+									toggleBranch(UNKNOWN_SECTION);
+								}}
+							>
+								<span class="shrink-0 text-gray-400">
+									{expandedBranches.has(UNKNOWN_SECTION) ? '−' : '+'}
+								</span>
+								<span class="min-w-0 truncate font-medium text-gray-400">No branch found</span>
+								<span class="ml-auto shrink-0 text-[10px] text-gray-400">
+									{grouped.unknown.length}
+								</span>
+							</button>
+							{#if expandedBranches.has(UNKNOWN_SECTION)}
+								<div class="mb-1 ml-3 border-l border-secondary-600 pl-1 dark:border-space-700">
+									<p class="px-2 pb-1 text-[10px] leading-tight text-gray-500">
+										These builds have no branch info attached — nothing is wrong with them.
+									</p>
+									{#each grouped.unknown as entry (entry.key)}
+										{@const isSelected = entry.commit === selectedSha}
+										<button
+											type="button"
+											aria-current={isSelected ? 'true' : undefined}
+											class="flex w-full flex-row items-center gap-2 rounded px-2 py-1 text-left text-xs hover:bg-secondary-700 dark:hover:bg-space-900"
+											class:bg-secondary-700={isSelected}
+											class:dark:bg-space-900={isSelected}
+											class:ring-1={isSelected}
+											class:ring-inset={isSelected}
+											class:ring-primary-400={isSelected}
+											on:click={() => {
+												selectEntry(entry.commit);
+											}}
+										>
+											<span class="shrink-0 font-mono text-gray-400">
+												{shortSha(entry.commit)}
+											</span>
+											<span class="min-w-0 flex-1 truncate text-gray-300">
+												{messageFor(entry.commit)}
+											</span>
+											<span class="w-12 shrink-0 text-right text-gray-400">
+												{formatRelativeAge(entry.lastModified)}
+											</span>
+										</button>
+									{/each}
+								</div>
+							{/if}
+						{/if}
+					{/if}
+				</div>
+			{/if}
+		</div>
+
+		{#if onManualEntry}
+			<div class="mt-1 flex flex-row justify-end">
+				<button
+					type="button"
+					class="rounded px-1 text-[10px] text-primary-400 underline underline-offset-2 hover:text-primary-300"
+					on:click={handleManualEntry}
+				>
+					Enter a commit manually
+				</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	/* Only vertical text in the product; a plain CSS property in a scoped block is more portable
+	   across WebKitGTK (Linux) and WebView2 (Windows) than a Tailwind arbitrary-value class. */
+	.rail-label {
+		writing-mode: vertical-rl;
+		text-orientation: mixed;
+		white-space: nowrap;
+	}
+</style>

--- a/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
+++ b/friendshipper/src/lib/components/playtests/PlaytestModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { Button, Checkbox, Input, Label, Modal, Select, Tooltip, Helper } from 'flowbite-svelte';
-	import { EditOutline, ExclamationCircleOutline, UndoOutline } from 'flowbite-svelte-icons';
+	import { ExclamationCircleOutline, UndoOutline } from 'flowbite-svelte-icons';
 	import { emit } from '@tauri-apps/api/event';
 	import type {
 		ArtifactEntry,
+		CommitWorkflowInfo,
 		Nullable,
 		Playtest,
 		PlaytestSpec,
@@ -18,8 +19,10 @@
 		workflowMap,
 		builds
 	} from '$lib/stores';
-	import { getBuild, getBuilds } from '$lib/builds';
+	import { getBuild, getBuilds, getWorkflows } from '$lib/builds';
 	import { getServerArgsDisplayString } from '$lib/gameServers';
+	import { resolveTrunkBranch, isTrunkBuild } from '$lib/utils';
+	import BuildPicker from './BuildPicker.svelte';
 
 	export let versions: ArtifactEntry[];
 	export let showModal: boolean;
@@ -30,12 +33,22 @@
 	let prevProject: string | null = null;
 	let showConfirmation: boolean = false;
 
-	let commits: { name: string; value: string }[] = [];
+	// Full entries rather than {name,value} pairs — BuildPicker needs `lastModified` and `key` too.
+	let pickerVersions: ArtifactEntry[] = [];
+	// Component-local: the global `workflows` store has readers on other routes and no restore path.
+	let projWorkflowMap: Map<string, CommitWorkflowInfo> = new Map();
+	// Re-entrancy guard for getProjectValues — see the reactive block below.
+	let getProjectValuesRunId = 0;
 	let maps: { value: string; name: string }[] = [];
 	let profiles: { value: PlaytestProfile; name: string }[] = [];
 	let submitting = false;
 	let deleting = false;
 	let project: string = '';
+
+	// Controlled selection: replaces the `<Select>`'s one-way `value` and the FormData read.
+	let selectedVersion: string = '';
+	// The sha the playtest is saved with (Editing only) — drives BuildPicker's "Current" row.
+	let originalSha: string | null = null;
 
 	let playtestError: string | null = null;
 	let nameError: boolean = false;
@@ -47,8 +60,10 @@
 
 	let commitSelectMode: CommitSelectMode = CommitSelectMode.Default;
 
-	const getCommitPhase = (commit: string): string => {
-		const commitWorkflow = $workflowMap.get(commit);
+	// Takes the map explicitly: the global store is written once at app start, for the default
+	// project only, so reading it here filtered nothing for other projects and went stale for this one.
+	const getCommitPhase = (commit: string, wfMap: Map<string, CommitWorkflowInfo>): string => {
+		const commitWorkflow = wfMap.get(commit);
 		if (!commitWorkflow) return 'unknown';
 
 		// if any workflow is running, return "Running"
@@ -70,39 +85,48 @@
 		return 'unknown';
 	};
 
-	const getBranchInfo = (commit: string): { branch: string | null; isMain: boolean } => {
-		const commitWorkflow = $workflowMap.get(commit);
-		if (!commitWorkflow || !commitWorkflow.branch) {
-			return { branch: null, isMain: false };
-		}
-
-		const cleanBranchName = commitWorkflow.branch.replace('refs/heads/', '');
-		const isMain = cleanBranchName.toLowerCase() === 'main';
-
-		return { branch: cleanBranchName, isMain };
-	};
-
+	// `_item` is unused — it only keeps `playtest` in the reactive block's dependency set.
 	const getProjectValues = async (
-		item: Nullable<Playtest>,
+		_item: Nullable<Playtest>,
 		entries: ArtifactEntry[],
-		proj: Nullable<string>
+		proj: Nullable<string>,
+		runId: number
 	) => {
 		let projVersions = Array<ArtifactEntry>();
+		let workflowsResult: CommitWorkflowInfo[] = [];
 
 		if (proj) {
-			try {
-				projVersions = await getBuilds(250, proj).then((res) => res.entries);
-			} catch (getBuildsError) {
-				await emit('error', getBuildsError);
+			// Settled, not all: a workflows failure should cost branch attribution, not the build list.
+			const [buildsRes, workflowsRes] = await Promise.allSettled([
+				getBuilds(250, proj),
+				getWorkflows(false, proj)
+			]);
+
+			if (buildsRes.status === 'fulfilled') {
+				projVersions = buildsRes.value.entries;
+			} else {
+				await emit('error', buildsRes.reason);
 			}
 
+			if (workflowsRes.status === 'fulfilled') {
+				workflowsResult = workflowsRes.value.commits;
+			} else {
+				await emit('error', workflowsRes.reason);
+			}
+		} else {
+			projVersions = entries;
+			workflowsResult = $workflowMap.size > 0 ? Array.from($workflowMap.values()) : [];
+		}
+
+		// Every await is above this line and every write below it, so a superseded run touches nothing.
+		if (runId !== getProjectValuesRunId) return;
+
+		if (proj) {
 			// This is purposefully not being set in the global state. We want to update the maps for this Modal only.
 			if (prevProject === null) {
 				prevProject = $appConfig.selectedArtifactProject;
 			}
 			$appConfig.selectedArtifactProject = proj;
-		} else {
-			projVersions = entries;
 		}
 
 		maps = $activeProjectConfig?.maps.map((m) => ({ value: m, name: m })) ?? [];
@@ -112,32 +136,42 @@
 			value: p
 		}));
 
-		// Filter out failed builds from the available commits
-		const filteredVersions = projVersions.filter((v) => {
-			const phase = getCommitPhase(v.commit);
-			return phase !== 'Failed';
-		});
+		projWorkflowMap = new Map(workflowsResult.map((w) => [w.commit, w]));
 
-		commits = filteredVersions.map((v) => ({
-			value: v.commit,
-			name: v.commit
-		}));
+		// Drop failed builds, and sha-less ones: `commit` is `Option<String>` in Rust but `string` in
+		// types.ts, and a malformed S3 key would throw inside BuildPicker's keyed `{#each}`.
+		pickerVersions = projVersions.filter(
+			(v) => !!v.commit && getCommitPhase(v.commit, projWorkflowMap) !== 'Failed'
+		);
 
-		// If we have a version selected already, and it's older than the entire commit list,
-		// let's add it to the list to avoid confusion.
-		if (item != null && !commits.find((c) => c.value === item?.spec.version)) {
-			commits.push({
-				value: item.spec.version,
-				name: item.spec.version
-			});
+		// Only defaults in Creating mode; Editing seeds `selectedVersion` in handleOpen first.
+		// `pickerVersions` is newest-first across *every* branch, so `[0]` is often a feature-branch
+		// build — take the newest trunk build instead, falling back only if there is none.
+		if (selectedVersion === '') {
+			const trunk = resolveTrunkBranch($appConfig?.primaryBranch, $repoConfig?.targetBranches);
+			const newestTrunkBuild = pickerVersions.find((v) =>
+				isTrunkBuild(projWorkflowMap.get(v.commit)?.branch, trunk)
+			);
+			selectedVersion = newestTrunkBuild?.commit ?? pickerVersions[0]?.commit ?? '';
 		}
 	};
 
-	$: (async () => {
-		await getProjectValues(playtest, versions, project);
-	})().catch((e) => {
-		void emit('error', e);
-	});
+	// Via a helper so the reactive block does not take a dependency on the counter it writes.
+	const nextGetProjectValuesRunId = (): number => {
+		getProjectValuesRunId += 1;
+		return getProjectValuesRunId;
+	};
+
+	// Carries two network calls, so the run id is captured here and rechecked past the awaits:
+	// only the last-fired run writes state. In-flight requests are not cancelled, just discarded.
+	$: void (async () => {
+		const runId = nextGetProjectValuesRunId();
+		try {
+			await getProjectValues(playtest, versions, project, runId);
+		} catch (e) {
+			await emit('error', e);
+		}
+	})();
 
 	const projects = $allProjects?.map((p) => ({
 		value: p,
@@ -147,7 +181,8 @@
 	const getPlaytestProject = (item: Nullable<Playtest>): string => {
 		if (item === null) return projects?.[0]?.value ?? '';
 
-		if (item.metadata.annotations === null) return '';
+		// `== null`: kube omits the annotations key entirely, so it arrives `undefined`, not `null`.
+		if (item.metadata.annotations == null) return '';
 
 		return item.metadata.annotations['believer.dev/project'] ?? '';
 	};
@@ -169,6 +204,14 @@
 		submitting = true;
 		playtestError = '';
 
+		// Captured before the first await: Escape stays live during submit, and `handleClose` blanking
+		// `project` mid-flight would write an empty `believer.dev/project` annotation.
+		const submitMode = mode;
+		const submitPlaytest = playtest;
+		const submitProject = project;
+		const submitVersion = selectedVersion;
+		const knownVersions = pickerVersions;
+
 		const formData = new FormData(e.target as HTMLFormElement);
 		const data: Record<string, string> = {};
 		for (const field of formData) {
@@ -183,6 +226,16 @@
 			return;
 		}
 
+		if (!submitVersion) {
+			playtestError = 'A build version is required.';
+			submitting = false;
+			return;
+		}
+
+		// Keyed off the value, not the mode: a hand-typed sha survives the Undo back to Default, and
+		// nothing validates it server-side. Anything absent from the list gets the pre-flight.
+		const needsBuildPreflight = !knownVersions.some((v) => v.commit === submitVersion);
+
 		let gameServerCmdArgs: string[] = [];
 		if (data.profile !== undefined) {
 			const selectedProfileName = data.profile;
@@ -192,40 +245,42 @@
 			}
 		}
 
-		if (mode === ModalState.Editing && playtest != null) {
+		if (submitMode === ModalState.Editing && submitPlaytest != null) {
 			const doNotPrune = !('autoCleanup' in data);
 			const spec: PlaytestSpec = {
-				displayName: playtest.spec.displayName,
-				version: data.version,
+				displayName: submitPlaytest.spec.displayName,
+				version: submitVersion,
 				map: data.map,
 				minGroups: parseInt(data.minGroups, 10),
 				playersPerGroup: parseInt(data.maxPlayersPerGroup, 10),
 				startTime: new Date(`${data.startDate} ${data.startTime}`).toISOString(),
-				groups: playtest.spec.groups,
+				groups: submitPlaytest.spec.groups,
 				feedbackURL: data.feedbackURL,
-				includeReadinessProbe: playtest?.spec.includeReadinessProbe ?? false,
+				includeReadinessProbe: submitPlaytest.spec.includeReadinessProbe ?? false,
 				gameServerCmdArgs,
-				disableGameServers: playtest?.spec.disableGameServers ?? false
+				disableGameServers: submitPlaytest.spec.disableGameServers ?? false
 			};
 
 			try {
-				if (commitSelectMode === CommitSelectMode.Custom) {
-					await getBuild(data.version, data.project);
+				if (needsBuildPreflight) {
+					// `|| undefined`: '' would arrive as `Some("")` and defeat the backend's fallback.
+					// (`data.project` is undefined in Editing mode — the Project <Select> is disabled.)
+					await getBuild(submitVersion, submitProject || undefined);
 				}
 
-				await updatePlaytest(playtest?.metadata.name, project, doNotPrune, spec);
+				await updatePlaytest(submitPlaytest.metadata.name, submitProject, doNotPrune, spec);
 			} catch (updateError) {
 				playtestError = (updateError as Error).message;
 				submitting = false;
 				return;
 			}
-		} else if (mode === ModalState.Creating) {
+		} else if (submitMode === ModalState.Creating) {
 			const doNotPrune = !('autoCleanup' in data);
 			const includeReadinessProbe = 'includeReadinessProbe' in data;
 			const disableGameServers = 'disableGameServers' in data;
 			const spec: PlaytestSpec = {
 				displayName: data.name,
-				version: data.version,
+				version: submitVersion,
 				map: data.map,
 				minGroups: parseInt(data.minGroups, 10),
 				playersPerGroup: parseInt(data.maxPlayersPerGroup, 10),
@@ -240,8 +295,10 @@
 			const name = data.name.toLowerCase().replace(/[_\s/]/g, '-');
 
 			try {
-				if (commitSelectMode === CommitSelectMode.Custom) {
-					await getBuild(data.version, data.project);
+				if (needsBuildPreflight) {
+					// `data.project` is the authority in Creating mode - the Project <Select> is enabled and
+					// only one-way bound, so `project` does not track the user's choice.
+					await getBuild(submitVersion, data.project || undefined);
 				}
 				await createPlaytest(name, data.project, doNotPrune, spec);
 			} catch (createError) {
@@ -253,9 +310,6 @@
 
 		submitting = false;
 		showModal = false;
-
-		// Put the real project back in the global state.
-		$appConfig.selectedArtifactProject = prevProject ?? '';
 
 		onSubmit();
 	};
@@ -288,7 +342,25 @@
 			commitSelectMode = CommitSelectMode.Default;
 		}
 
+		// Order matters: assigning `project` fires the reactive block, and `selectedVersion` must
+		// already be set in Editing mode so the auto-default no-ops.
+		selectedVersion = playtest?.spec.version ?? '';
+		originalSha = playtest?.spec.version ?? null;
 		project = getPlaytestProject(playtest);
+	};
+
+	// Runs on every close path — submit, delete, close-X and Escape. The null check matters: with
+	// nothing captured there is nothing to restore, and writing '' would re-point activeProjectConfig.
+	const handleClose = () => {
+		if (prevProject !== null) {
+			$appConfig.selectedArtifactProject = prevProject;
+			prevProject = null;
+		}
+
+		// Keeps the restore above from being undone: the component stays mounted, so a refreshed
+		// `versions` re-fires the reactive block on a closed modal, which would re-point the global
+		// value again. Also bumps the run id, discarding any fetch still in flight.
+		project = '';
 	};
 
 	const getPlaytestDate = (item: Nullable<Playtest>): string => {
@@ -314,6 +386,7 @@
 	dialogClass="fixed mt-8 top-0 start-0 end-0 h-modal md:inset-0 md:h-full z-50 w-full p-4 pb-12 flex"
 	bind:open={showModal}
 	on:open={handleOpen}
+	on:close={handleClose}
 >
 	<form class="flex flex-col space-y-4" action="#" on:submit|preventDefault={handleSubmit}>
 		<h4 class="flex items-center gap-3 text-lg font-semibold text-primary-400">
@@ -366,90 +439,66 @@
 				required
 			/>
 		</Label>
-		<div class="flex flex-row gap-2">
-			<Label class="space-y-2 text-xs text-white w-1/2">
-				<span>Version</span>
-				<div class="flex flex-row gap-2 w-full">
-					{#if commitSelectMode === CommitSelectMode.Default}
-						<Select
-							size="sm"
-							name="version"
-							class={inputClass}
-							value={playtest ? playtest.spec.version : commits[0]?.value ?? ''}
-							required
-						>
-							{#each commits as commit}
-								{@const branchInfo = getBranchInfo(commit.value)}
-								<option
-									value={commit.value}
-									class={branchInfo.isMain ? 'text-green-400' : 'text-blue-400'}
-								>
-									{commit.name.substring(0, 8)}
-									{branchInfo.branch && !branchInfo.isMain ? ` (${branchInfo.branch})` : ''}
-									{$workflowMap.get(commit.name)?.message || ''}
-								</option>
-							{/each}
-						</Select>
-						<Button
-							size="xs"
-							on:click={() => {
-								commitSelectMode = CommitSelectMode.Custom;
-							}}
-						>
-							<EditOutline />
-						</Button>
-						<Tooltip
-							placement="bottom"
-							class="w-auto text-xs text-primary-400 bg-secondary-600 dark:bg-space-800"
-						>
-							Enter commit manually
-						</Tooltip>
-					{:else}
-						<Input
-							type="text"
-							class={inputClass}
-							size="sm"
-							name="version"
-							value={playtest ? playtest.spec.version : commits[0]?.value ?? ''}
-							required
-						/>
-						<Button
-							size="xs"
-							on:click={() => {
-								commitSelectMode = CommitSelectMode.Default;
-							}}
-						>
-							<UndoOutline />
-						</Button>
-						<Tooltip
-							placement="bottom"
-							class="w-auto text-xs text-primary-400 bg-secondary-600 dark:bg-space-800"
-						>
-							Use commit from recent commits list
-						</Tooltip>
-					{/if}
-				</div>
-			</Label>
-			<Label class="space-y-2 text-xs text-white w-1/2">
-				<span>Map</span>
-				<Select
-					size="sm"
-					name="map"
-					class={inputClass}
-					value={playtest ? playtest.spec.map : maps[0]?.value ?? ''}
-					required
-				>
-					{#each maps as map}
-						<option value={map.value}>{map.name}</option>
-					{/each}
-				</Select>
-			</Label>
+		<!-- Not a flowbite <Label>: it renders a <label> with no `for`, which implicitly targets
+		     BuildPicker's summary <button>, so clicks on the open panel's dead space collapsed it.
+		     The classes below are what <Label class="space-y-2 text-xs text-white"> resolves to. -->
+		<div class="space-y-2 text-xs font-medium text-white rtl:text-right dark:text-gray-300">
+			<span>Version</span>
+			<!-- items-start: without it, align-items:stretch grows the toggle button to the open
+			     panel's height. -->
+			<div class="flex w-full flex-row items-start gap-2">
+				{#if commitSelectMode === CommitSelectMode.Default}
+					<BuildPicker
+						versions={pickerVersions}
+						bind:selectedSha={selectedVersion}
+						workflowMap={projWorkflowMap}
+						trunkBranch={resolveTrunkBranch($appConfig?.primaryBranch, $repoConfig?.targetBranches)}
+						currentUserDisplayName={$appConfig?.userDisplayName ?? ''}
+						{originalSha}
+						onManualEntry={() => {
+							commitSelectMode = CommitSelectMode.Custom;
+						}}
+					/>
+				{:else}
+					<Input type="text" class={inputClass} size="sm" bind:value={selectedVersion} required />
+					<Button
+						type="button"
+						size="xs"
+						class="shrink-0"
+						on:click={() => {
+							commitSelectMode = CommitSelectMode.Default;
+						}}
+					>
+						<UndoOutline />
+					</Button>
+					<Tooltip
+						placement="bottom"
+						class="w-auto text-xs text-primary-400 bg-secondary-600 dark:bg-space-800"
+					>
+						Use commit from recent commits list
+					</Tooltip>
+				{/if}
+			</div>
 		</div>
 		{#if commitSelectMode === CommitSelectMode.Custom}
 			<span class="text-xs bg-red-700 text-white p-2 rounded-md">
 				Warning: The map list for manually entered commits may not be up to date.
 			</span>
 		{/if}
+		<Label class="space-y-2 text-xs text-white">
+			<span>Map</span>
+			<Select
+				size="sm"
+				name="map"
+				class={inputClass}
+				value={playtest ? playtest.spec.map : maps[0]?.value ?? ''}
+				required
+			>
+				{#each maps as map}
+					<option value={map.value}>{map.name}</option>
+				{/each}
+			</Select>
+		</Label>
 		<div class="flex flex-row gap-2">
 			<Label class="space-y-2 text-xs text-white w-full">
 				<span>Number of groups</span>

--- a/friendshipper/src/lib/components/workflows/WorkflowTable.svelte
+++ b/friendshipper/src/lib/components/workflows/WorkflowTable.svelte
@@ -14,6 +14,7 @@
 	import type { CommitWorkflowInfo, Nullable, Workflow } from '$lib/types';
 	import { stopWorkflow, getWorkflowNodes } from '$lib/builds';
 	import { appConfig, repoConfig } from '$lib/stores';
+	import { resolveTrunkBranch } from '$lib/utils';
 
 	export let selectedCommit = '';
 	export let showWorkflowLogsModal = false;
@@ -146,15 +147,10 @@
 	const isPrimaryBranch = (branch: string | null): boolean => {
 		if (!branch) return false;
 		const cleanBranchName = formatBranchName(branch).toLowerCase();
-
-		// Get primary branch from config, with fallback to first target branch, then "main"
-		let primaryBranch = $appConfig?.primaryBranch;
-		if (!primaryBranch && $repoConfig?.targetBranches?.length > 0) {
-			primaryBranch = $repoConfig.targetBranches[0].name;
-		}
-		if (!primaryBranch) {
-			primaryBranch = 'main';
-		}
+		const primaryBranch = resolveTrunkBranch(
+			$appConfig?.primaryBranch,
+			$repoConfig?.targetBranches
+		);
 
 		return cleanBranchName === primaryBranch.toLowerCase();
 	};

--- a/friendshipper/src/lib/utils.ts
+++ b/friendshipper/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { emit } from '@tauri-apps/api/event';
+import type { TargetBranchConfig } from '$lib/types';
 
 export const openUrl = async (url: string) => {
 	await invoke('open_url', { url });
@@ -43,4 +44,43 @@ export const logInfo = async (message: string) => {
 	} catch (_) {
 		// Ignore if logging command fails
 	}
+};
+
+export const resolveTrunkBranch = (
+	primaryBranch: string | undefined | null,
+	targetBranches: TargetBranchConfig[] | undefined | null
+): string => {
+	if (primaryBranch) return primaryBranch;
+	if (targetBranches && targetBranches.length > 0) return targetBranches[0].name;
+	return 'main';
+};
+
+export const cleanBranchName = (branch: string): string => branch.replace(/^refs\/heads\//, '');
+
+// Argo writes the branch label with `refs/heads/` stripped and every `/` rewritten as `_` (see
+// docs/build-artifacts.md:75), so `release/2025.1` arrives as `release_2025.1`. Normalize both
+// sides before comparing. Display of branch names is left untouched.
+const normalizeBranchForTrunkMatch = (branch: string): string =>
+	cleanBranchName(branch).replace(/\//g, '_').toLowerCase();
+
+export const isTrunkBuild = (branch: string | null | undefined, trunkBranch: string): boolean => {
+	if (!branch || !trunkBranch) return false;
+	return normalizeBranchForTrunkMatch(branch) === normalizeBranchForTrunkMatch(trunkBranch);
+};
+
+export const formatRelativeAge = (
+	lastModifiedSeconds: number,
+	nowMs: number = Date.now()
+): string => {
+	const diffSeconds = nowMs / 1000 - lastModifiedSeconds;
+
+	if (diffSeconds < 60) return 'just now';
+	if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m`;
+	if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)}h`;
+	if (diffSeconds < 30 * 86400) return `${Math.floor(diffSeconds / 86400)}d`;
+
+	return new Date(lastModifiedSeconds * 1000).toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric'
+	});
 };


### PR DESCRIPTION
## Summary

The playtest modal picked a build from one flat `<Select>`, with trunk builds tinted green and
everything else blue. At realistic build volumes that's hard to read: branch builds from unrelated
work interleave with trunk history, the branch name is crammed into the option label, and there's no
way to tell whether a branch build is newer or older than the latest main.

This replaces it with a picker that gives **trunk the whole panel** — the answer most of the time —
and keeps branch builds one click away behind a collapsible rail. Exactly one side is expanded at a
time; the other collapses to a 34px edge, so trunk is always left and branches always right.

- Builds group under their branch, newest-first, with an age gutter on every row.
- Your own branch sections sort first and start expanded; everyone else's start collapsed.
- Builds whose branch can't be determined get their own **grey** group instead of rendering blue and
  being indistinguishable from a real dev branch.
- Creating a playtest defaults to the newest **trunk** build, not the newest build overall.
- When editing, a persistent "Current" row keeps the saved build reachable.
- `Map` moves to its own row so the version field spans the modal's full width.
- The panel expands **inline** rather than floating — the modal card and flowbite's `Modal` body div
  both set `overflow-y-auto`, which would clip an absolutely-positioned panel.

### Backend

Branch attribution comes from joining build shas against workflow data, but `get_workflows` took only
`engine: bool` and resolved the project from Rust-side app config — so changing the modal's Project
dropdown left the workflow map pointing at the wrong project. `GetWorkflowsParams` now accepts
`project: Option<String>`, threaded through `command.rs` and `builds.ts`, mirroring `get_builds`'
existing fallback. The result is held in **component-local** state; the global `workflows` store has
several readers across three routes and no restore path, so a modal-scoped write would leak.

## Defects fixed along the way

All in the call sites this PR was already rewriting:

- **Selection silently reset to the newest build** whenever the build list refreshed on window focus.
- **The artifact project was restored only on successful submit** — not on cancel, close, or delete —
  and was re-leaked every refresh by the *closed* modal, since the component stays mounted.
- **Closing the modal mid-submit corrupted the playtest's project annotation.** `handleSubmit` re-read
  `project` after its `await`, and Escape could blank it first, writing `believer.dev/project: ""`.
- **A hand-typed sha survived the toggle back to list mode unvalidated**, so a nonexistent commit
  could be persisted. Validation now depends on whether the sha is in the list, not on which mode
  you're in.
- **The failed-build filter silently no-op'd**, reading a global map written only at app start, so a
  build that failed after startup could be auto-selected.
- **`getBuild` validated an edited playtest's sha against the backend's configured project** rather
  than the playtest's own.
- **Escape while the picker was open destroyed the whole modal**, discarding unsaved edits.
- **A `usize` underflow panic** on an `engine_repo_url` containing no `/`.
- **A null `commit` blanked the entire picker** — `ArtifactEntry.commit` is `Option<String>` in Rust
  but `string` in TypeScript, so one malformed S3 key threw inside a keyed `{#each}`.
- **Trunk matching failed for slashed branch names.** The Argo sensor label rewrites `/` to `_`
  (`friendshipper/docs/build-artifacts.md:75`), so `release/2025.1` arrived as `release_2025.1` and
  never matched.

## Test plan

Automated, all green locally after rebasing onto `main`:

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features -p friendshipper -- -D warnings`
- [x] `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --release -p friendshipper --lib` — 63 passed, including 7 new tests covering the
      project-resolution precedence (the `engine` override must win unconditionally, or `/builds`
      breaks)
- [x] `yarn run check` — no new svelte-check errors
- [x] `yarn build`, `yarn tauri:build`

Exercised in a running app against a real repo; the layout and Escape-handling issues found there are
fixed. The following are **not** verified and want a reviewer's eyes:

- [ ] Creating a playtest preselects the newest **trunk** build (green), not the newest branch build —
      and submitting untouched saves that sha
- [ ] Round trip: create → reopen in Edit (shows the saved sha) → change → submit → reopen
- [ ] Clicking a build row never submits the form
- [ ] Empty version is rejected with `A build version is required.`
- [ ] Switching Project re-scopes branch grouping instead of dumping everything into the grey group
- [ ] The artifact project is restored on all four exits — submit, close-X, Escape, Delete — and does
      not drift back after the modal is closed
- [ ] **Vertical rail text renders correctly on both WebKitGTK (Linux) and WebView2 (Windows)** —
      `writing-mode` has no precedent in this repo, and this is the likeliest visual failure
- [ ] Your own branch sections start expanded and sort first
- [ ] `/builds` still tints trunk green / branches blue, and `getWorkflows(true)` still returns engine
      workflows

## Known limitations, deliberately not addressed

- **`commitSelectMode` is decided from the global, project-less build list**, so editing a playtest
  from a non-default project still opens in manual-sha mode, and the new "Current" row can't render
  for a build that has aged out of the 250-build window. Pre-existing; worth its own change.
- **"Yours" detection is best-effort.** `pusher` is a VCS login while `userDisplayName` is free text,
  so it may not match for anyone. Failure mode is a missing convenience, never a wrong build.
- **If the workflows fetch fails**, builds still list (they're settled independently) but all
  attribution is lost, so everything lands in the grey group and the default falls back to
  newest-overall.
- The 250-build / 250-workflow ceiling is unchanged; older builds lose attribution and surface in the
  grey group rather than being silently mislabelled.

Originates from keitora task #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
